### PR TITLE
Bump mina docker to 3.1.0

### DIFF
--- a/docs/berkeley-upgrade/archive-migration/mainnet-database-maintenance.mdx
+++ b/docs/berkeley-upgrade/archive-migration/mainnet-database-maintenance.mdx
@@ -143,7 +143,7 @@ where:
 
 :warning: Running a replayer from scratch on a Devnet/Mainnet database can take up to a couple of days. The recommended best practice is to break the replayer into smaller parts by using the checkpoint capabilities of the replayer.
 
-:warning: You must run the replayer using the Mainnet version. You can run it from the Docker image at `minaprotocol/mina-archive:3.0.3-d800da8-bullseye`.
+:warning: You must run the replayer using the Mainnet version. You can run it from the Docker image at `minaprotocol/mina-archive:3.1.0-ae112d3-bullseye`.
 
 ## Missing blocks
 
@@ -155,7 +155,7 @@ If you uploaded the missing blocks to Google Cloud, the missing blocks can be re
 
    The `download-missing-blocks` script uses `localhost` as the database host so the script assumes that psql is running on localhost on port 5432. Modify `PG_CONN` in `download_missing_block.sh` for your environment.
 
-1. Install the required `mina-archive-blocks` and `mina-missing-blocks-auditor` scripts that are packed in the `minaprotocol/mina-archive:3.0.3-d800da8-bullseye` Docker image.
+1. Install the required `mina-archive-blocks` and `mina-missing-blocks-auditor` scripts that are packed in the `minaprotocol/mina-archive:3.1.0-ae112d3-bullseye` Docker image.
 
 1. Export the `BLOCKS_BUCKET`:
 
@@ -183,7 +183,7 @@ O1labs maintains a Google bucket containing precomputed blocks from Devnet and M
 Note: It's important to highlight that precomputed blocks for **Devnet** between heights `2` and `1582` have missing fields or incorrect transaction data. Utilizing these blocks to patch your Devnet archive database will result in failure. For those who rely on precomputed blocks from this bucket, please follow the outlined steps:
 
 1. Download additional blocks from `gs://mina_network_block_data/devnet-extensional-bundle.tar.gz`.
-2. Install the necessary `mina-archive-blocks` script contained within the `minaprotocol/mina-archive:3.0.3-d800da8-bullseye` Docker image.
+2. Install the necessary `mina-archive-blocks` script contained within the `minaprotocol/mina-archive:3.1.0-ae112d3-bullseye` Docker image.
 3. Execute mina-archive-blocks to import the extracted blocks from step 1 using the provided command:
 
       ```sh

--- a/docs/berkeley-upgrade/flags-configs.mdx
+++ b/docs/berkeley-upgrade/flags-configs.mdx
@@ -127,7 +127,7 @@ docker run
 --name rosetta --rm \
 -p 3088:3088 \
 --entrypoint '' \
-minaprotocol/mina-rosetta:3.0.3-d800da8-bullseye-mainnet \
+minaprotocol/mina-rosetta:3.1.0-ae112d3-bullseye-mainnet \
 /usr/local/bin/mina-rosetta \
 --archive-uri "${PG_CONNECTION_STRING}" \
 --graphql-uri "${GRAPHQL_URL}" \

--- a/docs/berkeley-upgrade/requirements.mdx
+++ b/docs/berkeley-upgrade/requirements.mdx
@@ -30,7 +30,7 @@ Please note the following are the hardware requirements for each node type after
 
 :::caution
 
-If you have `mina-generate-keypair` installed, you will need to first `sudo apt remove mina-generate-keypair` before installing `mina-mainnet=3.0.3-d800da8`.
+If you have `mina-generate-keypair` installed, you will need to first `sudo apt remove mina-generate-keypair` before installing `mina-mainnet=3.1.0-ae112d3`.
 The `mina-generate-keypair` binary is now installed as part of the mina-mainnet package.
 
 :::

--- a/docs/exchange-operators/rosetta/docker-compose.mdx
+++ b/docs/exchange-operators/rosetta/docker-compose.mdx
@@ -35,7 +35,7 @@ services:
     ports:
       - '5432:5432'
   bootstrap_db:
-    image: 'minaprotocol/mina-archive:3.0.3-d800da8-bullseye'
+    image: 'minaprotocol/mina-archive:3.1.0-ae112d3-bullseye'
     command: >
       bash -c '
       curl -O https://673156464838-mina-archive-node-backups.s3.us-west-2.amazonaws.com/mainnet/mainnet-archive-dump-$(date +%F_0000).sql.tar.gz;
@@ -52,7 +52,7 @@ services:
       postgres:
         condition: service_healthy
   missing_blocks_guardian:
-    image: 'minaprotocol/mina-archive:3.0.3-d800da8-bullseye'
+    image: 'minaprotocol/mina-archive:3.1.0-ae112d3-bullseye'
     command: >
       bash -c '
       curl -O https://raw.githubusercontent.com/MinaFoundation/helm-charts/main/mina-archive/scripts/missing-blocks-guardian-command.sh;
@@ -65,7 +65,7 @@ services:
       bootstrap_db:
         condition: service_completed_successfully
   mina_archive:
-    image: 'minaprotocol/mina-archive:3.0.3-d800da8-bullseye'
+    image: 'minaprotocol/mina-archive:3.1.0-ae112d3-bullseye'
     restart: always
     command:
       - mina-archive
@@ -80,7 +80,7 @@ services:
       bootstrap_db:
         condition: service_completed_successfully
   mina_node:
-    image: 'minaprotocol/mina-daemon:3.0.3-d800da8-bullseye-mainnet'
+    image: 'minaprotocol/mina-daemon:3.1.0-ae112d3-bullseye-mainnet'
     restart: always
     environment:
       MINA_LIBP2P_PASS: PssW0rD
@@ -100,7 +100,7 @@ services:
       bootstrap_db:
         condition: service_completed_successfully
   mina_rosetta:
-    image: 'minaprotocol/mina-rosetta:3.0.3-d800da8-bullseye-mainnet'
+    image: 'minaprotocol/mina-rosetta:3.1.0-ae112d3-bullseye-mainnet'
     restart: always
     environment:
       MINA_ROSETTA_MAX_DB_POOL_SIZE: 80

--- a/docs/exchange-operators/rosetta/run-with-docker.mdx
+++ b/docs/exchange-operators/rosetta/run-with-docker.mdx
@@ -47,7 +47,7 @@ Run the container with following command (replace the image tag with one from do
     docker run -it --rm --name rosetta \
         --entrypoint=./docker-start.sh \
         -p 10101:10101 -p 3085:3085 -p 3086:3086 -p 3087:3087 \
-        minaprotocol/mina-rosetta:3.0.3-d800da8-bullseye-mainnet
+        minaprotocol/mina-rosetta:3.1.0-ae112d3-bullseye-mainnet
 ```
 
 You can also create a file with the environment variables and pass it to the docker run command with `--env-file` flag. For example, create a file named `mainnet.env` with the following content:

--- a/docs/node-developers/sandbox-node.mdx
+++ b/docs/node-developers/sandbox-node.mdx
@@ -26,7 +26,7 @@ docker run \
   --name mina \
   -e RUN_DEMO=true \
   -e MINA_PRIVKEY_PASS='' \
-  minaprotocol/mina-daemon:3.0.3-d800da8-bullseye-mainnet
+  minaprotocol/mina-daemon:3.1.0-ae112d3-bullseye-mainnet
 
 ```
 

--- a/docs/node-operators/archive-node/docker-compose.mdx
+++ b/docs/node-operators/archive-node/docker-compose.mdx
@@ -32,8 +32,8 @@ services:
     ports:
       - '5432:5432'
   bootstrap_db:
-    image: 'minaprotocol/mina-archive:3.0.3-d800da8-bullseye'
-    # image: 'gcr.io/o1labs-192920/mina-archive:3.0.1-alpha1-0473756-bullseye' # Use this image for Devnet
+    image: 'minaprotocol/mina-archive:3.1.0-ae112d3-bullseye'
+    # image: 'gcr.io/o1labs-192920/mina-archive:3.1.0-alpha1-56cdb61-bullseye' # Use this image for Devnet
     command: >
       bash -c '
       curl -O https://673156464838-mina-archive-node-backups.s3.us-west-2.amazonaws.com/mainnet/mainnet-archive-dump-$(date +%F_0000).sql.tar.gz;
@@ -51,8 +51,8 @@ services:
       postgres:
         condition: service_healthy
   missing_blocks_guardian:
-    image: 'minaprotocol/mina-archive:3.0.3-d800da8-bullseye'
-    # image: 'gcr.io/o1labs-192920/mina-archive:3.0.1-alpha1-0473756-bullseye' # Use this image for Devnet
+    image: 'minaprotocol/mina-archive:3.1.0-ae112d3-bullseye'
+    # image: 'gcr.io/o1labs-192920/mina-archive:3.1.0-alpha1-56cdb61-bullseye' # Use this image for Devnet
     command: >
       bash -c '
       curl -O https://raw.githubusercontent.com/MinaFoundation/helm-charts/main/mina-archive/scripts/missing-blocks-guardian-command.sh;
@@ -66,7 +66,7 @@ services:
       bootstrap_db:
         condition: service_completed_successfully
   mina_archive:
-    image: 'minaprotocol/mina-archive:3.0.3-d800da8-bullseye'
+    image: 'minaprotocol/mina-archive:3.1.0-ae112d3-bullseye'
     restart: always
     command:
       - mina-archive
@@ -81,8 +81,8 @@ services:
       bootstrap_db:
         condition: service_completed_successfully
   mina_node:
-    image: 'minaprotocol/mina-daemon:3.0.3-d800da8-bullseye-mainnet'
-    # image: 'gcr.io/o1labs-192920/mina-daemon:3.0.1-alpha1-0473756-bullseye-devnet' # Use this image for Devnet
+    image: 'minaprotocol/mina-daemon:3.1.0-ae112d3-bullseye-mainnet'
+    # image: 'gcr.io/o1labs-192920/mina-daemon:3.1.0-alpha1-56cdb61-bullseye-devnet' # Use this image for Devnet
     restart: always
     entrypoint: []
     command: >

--- a/docs/node-operators/archive-node/getting-started.mdx
+++ b/docs/node-operators/archive-node/getting-started.mdx
@@ -55,13 +55,13 @@ Running an archive node requires some knowledge of managing a PostgreSQL databas
    - Ubuntu/Debian:
 
      ```
-     sudo apt-get install mina-archive=3.0.3-d800da8
+     sudo apt-get install mina-archive=3.1.0-ae112d3
      ```
 
    - Docker:
 
      ```
-     minaprotocol/mina-archive:3.0.3-d800da8-bullseye
+     minaprotocol/mina-archive:3.1.0-ae112d3-bullseye
      ```
 
 ## Set up the archive node
@@ -125,7 +125,7 @@ To get started with installing and running the archive node using Docker, follow
 2. Pull the archive node image from Docker Hub.
 
    ```sh
-   docker pull minaprotocol/mina-archive:3.0.3-d800da8-bullseye
+   docker pull minaprotocol/mina-archive:3.1.0-ae112d3-bullseye
    ```
 
 3. Pull and install the postgres image from Docker Hub.
@@ -168,7 +168,7 @@ To get started with installing and running the archive node using Docker, follow
    --name archive \
    -p 3086:3086 \
    -v /tmp/archive:/data \
-   minaprotocol/mina-archive:3.0.3-d800da8-bullseye \
+   minaprotocol/mina-archive:3.1.0-ae112d3-bullseye \
    mina-archive run \
    --postgres-uri postgres://postgres:postgres@postgres:5432/archive \
    --server-port 3086
@@ -212,7 +212,7 @@ To run the archive node using Docker Compose:
 3. Pull the archive node image from Docker Hub.
 
    ```sh
-   docker pull minaprotocol/mina-archive:3.0.3-d800da8-bullseye
+   docker pull minaprotocol/mina-archive:3.1.0-ae112d3-bullseye
    ```
 
 4. Pull and install the postgres image from Docker Hub.
@@ -240,7 +240,7 @@ To run the archive node using Docker Compose:
        ports:
          - '5432:5432'
      archive:
-       image: 'minaprotocol/mina-archive:3.0.3-d800da8-bullseye'
+       image: 'minaprotocol/mina-archive:3.1.0-ae112d3-bullseye'
        command: >-
          mina-archive run --postgres-uri
          postgres://postgres:postgres@postgres:5432/archive --server-port 3086

--- a/docs/node-operators/block-producer-node/connecting-to-devnet.mdx
+++ b/docs/node-operators/block-producer-node/connecting-to-devnet.mdx
@@ -126,7 +126,7 @@ docker run --name mina -d \
        --restart=always \
        -v $(pwd)/.mina-config:/data/.mina-config \
        -v $(pwd)/.mina-env:/entrypoint.d/mina-env \
-       gcr.io/o1labs-192920/mina-daemon:3.0.3-d800da8-bullseye-devnet \
+       gcr.io/o1labs-192920/mina-daemon:3.1.0-ae112d3-bullseye-devnet \
        daemon
 ```
 

--- a/docs/node-operators/block-producer-node/connecting-to-the-network.mdx
+++ b/docs/node-operators/block-producer-node/connecting-to-the-network.mdx
@@ -179,7 +179,7 @@ docker run --name mina -d \
 --mount "type=bind,source=$(pwd)/.mina-env,dst=/entrypoint.d/mina-env,readonly" \
 --mount "type=bind,source=$(pwd)/keys,dst=/keys,readonly" \
 --mount "type=bind,source=$(pwd)/.mina-config,dst=/root/.mina-config" \
-minaprotocol/mina-daemon:3.0.3-d800da8-bullseye-mainnet \
+minaprotocol/mina-daemon:3.1.0-ae112d3-bullseye-mainnet \
 daemon
 ```
 

--- a/docs/node-operators/block-producer-node/docker-compose.mdx
+++ b/docs/node-operators/block-producer-node/docker-compose.mdx
@@ -17,8 +17,8 @@ Copy and paste the provided configuration into a `docker-compose.yml` file. Then
 ```yaml
 services:
   generate_wallet_key:
-    image: 'minaprotocol/mina-daemon:3.0.3-d800da8-bullseye-mainnet'
-    # image: 'gcr.io/o1labs-192920/mina-daemon:3.0.1-alpha1-0473756-bullseye-devnet' # Use this image for Devnet
+    image: 'minaprotocol/mina-daemon:3.1.0-ae112d3-bullseye-mainnet'
+    # image: 'gcr.io/o1labs-192920/mina-daemon:3.1.0-alpha1-56cdb61-bullseye-devnet' # Use this image for Devnet
     environment:
       MINA_PRIVKEY_PASS: PssW0rD
     entrypoint: []
@@ -31,8 +31,8 @@ services:
     volumes:
       - './node/mina-config:/data/.mina-config'
   mina_block_producer:
-    image: 'minaprotocol/mina-daemon:3.0.3-d800da8-bullseye-mainnet'
-    # image: 'gcr.io/o1labs-192920/mina-daemon:3.0.1-alpha1-0473756-bullseye-devnet' # Use this image for Devnet
+    image: 'minaprotocol/mina-daemon:3.1.0-ae112d3-bullseye-mainnet'
+    # image: 'gcr.io/o1labs-192920/mina-daemon:3.1.0-alpha1-56cdb61-bullseye-devnet' # Use this image for Devnet
     restart: always
     environment:
       MINA_PRIVKEY_PASS: PssW0rD

--- a/docs/node-operators/block-producer-node/getting-started.mdx
+++ b/docs/node-operators/block-producer-node/getting-started.mdx
@@ -79,7 +79,7 @@ sudo apt-get update
 Now install the node package.
 
 ```
-sudo apt-get install -y curl unzip mina-mainnet=3.0.3-d800da8
+sudo apt-get install -y curl unzip mina-mainnet=3.1.0-ae112d3
 ```
 
 

--- a/docs/node-operators/data-and-history/rosetta.mdx
+++ b/docs/node-operators/data-and-history/rosetta.mdx
@@ -30,7 +30,7 @@ We recommend using Rosetta API if you are:
 
 1. [Install Docker](https://www.docker.com/get-started) and check that your Docker configuration has at least 12 GB RAM (the recommended amount is 16 GB).
 
-2. Use the official image `minaprotocol/mina-rosetta:3.0.3-d800da8-focal-mainnet`, which is built in exactly this way by buildkite CI/CD.
+2. Use the official image `minaprotocol/mina-rosetta:3.1.0-ae112d3-focal-mainnet`, which is built in exactly this way by buildkite CI/CD.
 
 :::note
 
@@ -61,7 +61,7 @@ To run docker-start.sh and connect to the live Mainnet:
     docker run -it --rm --name rosetta \
         --entrypoint=./docker-start.sh \
         -p 8302:8302 -p 3085:3085 -p 3086:3086 -p 3087:3087 \
-        minaprotocol/mina-rosetta:3.0.3-d800da8-focal-mainnet
+        minaprotocol/mina-rosetta:3.1.0-ae112d3-focal-mainnet
 
 
 #### Mainnet:Offline
@@ -73,7 +73,7 @@ To run docker-standalone-start.sh and connect to the offline Mainnet:
     docker run -it --rm --name rosetta \
         --entrypoint=./docker-standalone-start.sh \
         -p 8302:8302 -p 3085:3085 -p 3086:3086 -p 3087:3087 \
-        minaprotocol/mina-rosetta:3.0.3-d800da8-focal-mainnet
+        minaprotocol/mina-rosetta:3.1.0-ae112d3-focal-mainnet
 
 #### Demo:Offline
 
@@ -84,7 +84,7 @@ To run the docker-demo-start.sh and connect to the demo network:
     docker run -it --rm --name rosetta \
         --entrypoint=./docker-demo-start.sh \
         -p 8302:8302 -p 3085:3085 -p 3086:3086 -p 3087:3087 \
-        minaprotocol/mina-rosetta:3.0.3-d800da8-focal-mainnet
+        minaprotocol/mina-rosetta:3.1.0-ae112d3-focal-mainnet
 
 #### Devnet:Online
 

--- a/docs/node-operators/flags-configs.mdx
+++ b/docs/node-operators/flags-configs.mdx
@@ -127,7 +127,7 @@ docker run
 --name rosetta --rm \
 -p 3088:3088 \
 --entrypoint '' \
-minaprotocol/mina-rosetta:3.0.3-d800da8-bullseye-mainnet \
+minaprotocol/mina-rosetta:3.1.0-ae112d3-bullseye-mainnet \
 /usr/local/bin/mina-rosetta \
 --archive-uri "${PG_CONNECTION_STRING}" \
 --graphql-uri "${GRAPHQL_URL}" \

--- a/docs/node-operators/generating-a-keypair.mdx
+++ b/docs/node-operators/generating-a-keypair.mdx
@@ -93,7 +93,7 @@ Make sure to set a new and secure password for commands in follow-steps . Mina w
 ```
 echo "deb [trusted=yes] http://packages.o1test.net $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/mina.list
 sudo apt-get update
-sudo apt-get install -y mina-mainnet=3.0.3-d800da8
+sudo apt-get install -y mina-mainnet=3.1.0-ae112d3
 ```
 2. Verify that mina installed correctly:
 
@@ -121,7 +121,7 @@ mina advanced generate-keypair --privkey-path ~/keys/my-wallet
 cd ~
 docker run -it --rm --entrypoint "" \
        --volume $(pwd)/keys:/keys \
-       minaprotocol/mina-daemon:3.0.3-d800da8-bullseye-mainnet \
+       minaprotocol/mina-daemon:3.1.0-ae112d3-bullseye-mainnet \
        mina advanced generate-keypair --privkey-path /keys/my-wallet
 ```
 
@@ -155,7 +155,7 @@ On Docker:
 ```
 docker run -it --rm --entrypoint "" \
         --volume $(pwd)/keys:/keys \
-        minaprotocol/mina-daemon:3.0.3-d800da8-bullseye-mainnet \
+        minaprotocol/mina-daemon:3.1.0-ae112d3-bullseye-mainnet \
         mina advanced validate-keypair --privkey-path /keys/my-wallet
 ```
 

--- a/docs/node-operators/requirements.mdx
+++ b/docs/node-operators/requirements.mdx
@@ -30,7 +30,7 @@ Please note the following are the hardware requirements for each node type after
 
 :::caution
 
-If you have `mina-generate-keypair` installed, you will need to first `sudo apt remove mina-generate-keypair` before installing `mina-mainnet=3.0.3-d800da8`.
+If you have `mina-generate-keypair` installed, you will need to first `sudo apt remove mina-generate-keypair` before installing `mina-mainnet=3.1.0-ae112d3`.
 The `mina-generate-keypair` binary is now installed as part of the mina-mainnet package.
 
 :::

--- a/docs/node-operators/seed-peers/docker-compose.mdx
+++ b/docs/node-operators/seed-peers/docker-compose.mdx
@@ -16,7 +16,7 @@ Copy and paste the provided configuration into a `docker-compose.yml` file. Then
 ```yaml
 services:
   generate_libp2p_key:
-    image: 'minaprotocol/mina-daemon:3.0.3-d800da8-bullseye-mainnet'
+    image: 'minaprotocol/mina-daemon:3.1.0-ae112d3-bullseye-mainnet'
     environment:
       MINA_LIBP2P_PASS: PssW0rD
     entrypoint: []
@@ -29,8 +29,8 @@ services:
     volumes:
       - './node/mina-config:/data/.mina-config'
   mina_node:
-    image: 'minaprotocol/mina-daemon:3.0.3-d800da8-bullseye-mainnet'
-    # image: 'gcr.io/o1labs-192920/mina-daemon:3.0.1-alpha1-0473756-bullseye-devnet' # Use this image for Devnet
+    image: 'minaprotocol/mina-daemon:3.1.0-ae112d3-bullseye-mainnet'
+    # image: 'gcr.io/o1labs-192920/mina-daemon:3.1.0-alpha1-56cdb61-bullseye-devnet' # Use this image for Devnet
     restart: always
     environment:
       MINA_LIBP2P_PASS: PssW0rD

--- a/docs/node-operators/seed-peers/getting-started.mdx
+++ b/docs/node-operators/seed-peers/getting-started.mdx
@@ -88,7 +88,7 @@ docker run --name mina-seed-node -d \
 -v "$(pwd)/keys:/root/keys:ro" \
 -v "$(pwd)/.mina-config:/root/.mina-config" \
 -v "$(pwd)/.mina-env:/entrypoint.d/mina-env:ro" \
-minaprotocol/mina-daemon:3.0.3-d800da8-bullseye-mainnet \
+minaprotocol/mina-daemon:3.1.0-ae112d3-bullseye-mainnet \
 daemon
 ```
 

--- a/docs/node-operators/snark-workers/docker-compose.mdx
+++ b/docs/node-operators/snark-workers/docker-compose.mdx
@@ -17,8 +17,8 @@ Copy and paste the provided configuration into a `docker-compose.yml` file. Then
 ```yaml
 services:
   generate_wallet_key:
-    image: 'minaprotocol/mina-daemon:3.0.3-d800da8-bullseye-mainnet'
-    # image: 'gcr.io/o1labs-192920/mina-daemon:3.0.1-alpha1-0473756-bullseye-devnet' # Use this image for Devnet
+    image: 'minaprotocol/mina-daemon:3.1.0-ae112d3-bullseye-mainnet'
+    # image: 'gcr.io/o1labs-192920/mina-daemon:3.1.0-alpha1-56cdb61-bullseye-devnet' # Use this image for Devnet
     environment:
       MINA_PRIVKEY_PASS: PssW0rD
     entrypoint: []
@@ -31,8 +31,8 @@ services:
     volumes:
       - './node/mina-config:/data/.mina-config'
   mina_snark_coordinator:
-    image: 'minaprotocol/mina-daemon:3.0.3-d800da8-bullseye-mainnet'
-    # image: 'gcr.io/o1labs-192920/mina-daemon:3.0.1-alpha1-0473756-bullseye-devnet' # Use this image for Devnet
+    image: 'minaprotocol/mina-daemon:3.1.0-ae112d3-bullseye-mainnet'
+    # image: 'gcr.io/o1labs-192920/mina-daemon:3.1.0-alpha1-56cdb61-bullseye-devnet' # Use this image for Devnet
     restart: always
     environment:
       MINA_PRIVKEY_PASS: PssW0rD
@@ -60,8 +60,8 @@ services:
       generate_wallet_key:
         condition: service_completed_successfully
   mina_snark_worker:
-    image: 'minaprotocol/mina-daemon:3.0.3-d800da8-bullseye-mainnet'
-    # image: 'gcr.io/o1labs-192920/mina-daemon:3.0.1-alpha1-0473756-bullseye-devnet' # Use this image for Devnet
+    image: 'minaprotocol/mina-daemon:3.1.0-ae112d3-bullseye-mainnet'
+    # image: 'gcr.io/o1labs-192920/mina-daemon:3.1.0-alpha1-56cdb61-bullseye-devnet' # Use this image for Devnet
     restart: always
     entrypoint: []
     command: >

--- a/metadata.json
+++ b/metadata.json
@@ -1,8 +1,8 @@
 {
    "release":{
       "tags":{
-         "mainnet":"3.0.3-d800da8",
-         "devnet":"3.0.1-alpha1-0473756"
+         "mainnet":"3.1.0-ae112d3",
+         "devnet":"3.1.0-alpha1-56cdb61"
       }
    }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,8 +1,8 @@
 {
    "release":{
       "tags":{
-         "mainnet":"minaprotocol/mina-daemon:3.0.3-d800da8-bullseye-mainnet",
-         "devnet":"gcr.io/o1labs-192920/mina-daemon:3.0.1-alpha1-0473756-bullseye-devnet"
+         "mainnet":"3.0.3-d800da8",
+         "devnet":"3.0.1-alpha1-0473756"
       }
    }
 }


### PR DESCRIPTION
The 2nd commit is reproducible with
```
./scripts/update_release_tag.sh \
  3.1.0-ae112d3\
  3.1.0-alpha1-56cdb61
```

Some sections are still outdated, e.g. git commit hash. Let me update them in subsequent PRs.