### PR TITLE
Function `verify` returns `void` nowadays

### DIFF
--- a/docs/zkapps/o1js/recursion.mdx
+++ b/docs/zkapps/o1js/recursion.mdx
@@ -78,7 +78,7 @@ To verify this proof from within any method of your `SmartContract` class:
 
 ```typescript
 @method async foo(proof: SimpleProgram.Proof) {
-  proof.verify().assertTrue();
+  proof.verify();
   const output: Field = proof.value;
   // ...the rest of our method.
   // For example, storing the output of the execution of the program we've
@@ -148,7 +148,7 @@ Finally, verify the proof from within a SmartContract like the earlier example:
 
 ```typescript
 @method async foo(proof: Proof) {
-  proof.verify().assertTrue();
+  proof.verify();
   /* ... the rest of our method
    * For example using the total value as the fee for some other transaction. */
 }


### PR DESCRIPTION
Fix documentation