### PR TITLE
Uptime Service: remove outdated Coda key environment variable

### DIFF
--- a/docs/node-operators/delegation-program/uptime-tracking-system.mdx
+++ b/docs/node-operators/delegation-program/uptime-tracking-system.mdx
@@ -66,7 +66,6 @@ Here’s an example of what your .mina-env file should look like for Debian:
 EXTRA_FLAGS="--block-producer-key /home/mina/my-wallet --uptime-submitter-key /home/mina/my-wallet --uptime-url https://uptime-backend.minaprotocol.com/v1/submit"
 UPTIME_PRIVKEY_PASS=<CHANGE_ME_TO_MY_VERY_SECURE_PASSWORD>
 MINA_PRIVKEY_PASS=<CHANGE_ME_TO_MY_VERY_SECURE_PASSWORD>
-CODA_PRIVKEY_PASS=<CHANGE_ME_TO_MY_VERY_SECURE_PASSWORD>
 LOG_LEVEL=Info
 FILE_LOG_LEVEL=Debug
 ~~~


### PR DESCRIPTION
This is a simple one liner change. A ripgrep in mina's codebase on that env var returns none, so it's not used at all.