### PR TITLE
Add banner about o1labs docs site to o1js docs

### DIFF
--- a/docs/zkapps/o1js/basic-concepts.mdx
+++ b/docs/zkapps/o1js/basic-concepts.mdx
@@ -19,6 +19,11 @@ keywords:
   - methods
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
+
 # o1js Basic Concepts
 
 o1js is a TypeScript (TS) library for writing general-purpose zero knowledge (zk) programs and writing zk smart contracts for Mina.

--- a/docs/zkapps/o1js/bitwise-operations.mdx
+++ b/docs/zkapps/o1js/bitwise-operations.mdx
@@ -8,6 +8,10 @@ keywords:
   - o1js
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # Bitwise Operations
 
 Bitwise operations manipulate individual bits within a binary representation of a number. They can, at times, resemble boolean operations but apply to a sequence of bits instead of booleans. Bitwise operations are generally available in most programming languages, including TypeScript. o1js provides versions of them that operate on `Field` elements and result in the necessary circuit constraints to generate a zero knowledge proof of the computation. This is especially useful when implementing hashing algorithms such as SHA256.

--- a/docs/zkapps/o1js/circuit-writing-primer.mdx
+++ b/docs/zkapps/o1js/circuit-writing-primer.mdx
@@ -10,6 +10,10 @@ keywords:
   - o1js
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # Overview of the circuit-writing features in o1js
 
 o1js is a library for writing zk circuits in TypeScript.  While many high-level features are abstracted away from the circuit level, this article will focus specifically on the tools that are specific to the unique nature of writing circuits.

--- a/docs/zkapps/o1js/custom-tokens.mdx
+++ b/docs/zkapps/o1js/custom-tokens.mdx
@@ -15,6 +15,10 @@ keywords:
   - zkApps updates
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # Custom Token API
 
 You can use o1js to perform common token operations, such as minting, burning, and sending tokens.

--- a/docs/zkapps/o1js/ecdsa.mdx
+++ b/docs/zkapps/o1js/ecdsa.mdx
@@ -13,6 +13,10 @@ keywords:
   - blockchain
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # ECDSA
 
 ECDSA, or Elliptic Curve Digital Signature Algorithm, is a cryptographic algorithm used to sign and verify messages. It is used in many blockchains, including Ethereum, to sign transactions.

--- a/docs/zkapps/o1js/foreign-fields.mdx
+++ b/docs/zkapps/o1js/foreign-fields.mdx
@@ -10,6 +10,10 @@ keywords:
   - o1js
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # Foreign Field Arithmetic
 
 A foreign field is a [finite field](https://en.wikipedia.org/wiki/Modular_arithmetic) different from the native field of the proof system. o1js exposes operations like modular addition and multiplication that work in any finite field of size less than `2^259`.

--- a/docs/zkapps/o1js/gadgets.mdx
+++ b/docs/zkapps/o1js/gadgets.mdx
@@ -11,6 +11,10 @@ keywords:
   - blockchain
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # Gadgets
 
 Gadgets are small, reusable low-level building blocks that simplify the process of creating new cryptographic primitives. Most gadgets build upon custom gates and act as low-level accelerators in the proof system.

--- a/docs/zkapps/o1js/index.mdx
+++ b/docs/zkapps/o1js/index.mdx
@@ -18,6 +18,10 @@ keywords:
   - typescript library
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 :::info
 
 To protect end users and ensure your zkApps are secure, consider the information at [Security and zkApps](/zkapps/writing-a-zkapp/introduction-to-zkapps/secure-zkapps) while architecting your solution and consider a third-party security audit before deploying to Mina mainnet.

--- a/docs/zkapps/o1js/indexed-merkle-map.mdx
+++ b/docs/zkapps/o1js/indexed-merkle-map.mdx
@@ -15,6 +15,10 @@ description:
   - data structures
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 :::experimental
 
 The Indexed Merkle Map API is currently an experimental feature.

--- a/docs/zkapps/o1js/keccak.mdx
+++ b/docs/zkapps/o1js/keccak.mdx
@@ -12,6 +12,10 @@ keywords:
   - data structures
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # Keccak (SHA-3)
 
 Keccak is a flexible cryptographic hash function that provides more security than traditional SHA hash algorithms.

--- a/docs/zkapps/o1js/merkle-tree.mdx
+++ b/docs/zkapps/o1js/merkle-tree.mdx
@@ -11,6 +11,10 @@ keywords:
   - data structures
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # Merkle Tree
 
 zkApp accounts can store only a limited amount of data on chain so that Mina's chain remains succinct and does not become bloated.

--- a/docs/zkapps/o1js/recursion.mdx
+++ b/docs/zkapps/o1js/recursion.mdx
@@ -14,6 +14,10 @@ keywords:
   - blockchain compression
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # Recursion
 
 Kimchi, the custom proof system that backs o1js, supports arbitrary infinite recursive proof construction of circuits through integration with the Pickles recursive system. Mina Protocol is the only blockchain that offers infinite recursion.

--- a/docs/zkapps/o1js/sha256.mdx
+++ b/docs/zkapps/o1js/sha256.mdx
@@ -13,6 +13,10 @@ keywords:
   - data structures
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # SHA-256
 
 SHA-2 is a set of cryptographic hash functions designed by the National Security Agency (NSA) as an improved version of SHA-1, offering enhanced security and comprising multiple variants based on hash size, such as SHA-256 and SHA-512.

--- a/docs/zkapps/writing-a-zkapp/feature-overview/actions-and-reducer.mdx
+++ b/docs/zkapps/writing-a-zkapp/feature-overview/actions-and-reducer.mdx
@@ -14,6 +14,10 @@ keywords:
   - mina archive node
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 :::caution Warning
 The reducer API in o1js is currently not safe to use in production applications. The `reduce()` method breaks if more than the hard-coded number (default: 32) of actions are pending. Work is actively in progress to mitigate this limitation.
 

--- a/docs/zkapps/writing-a-zkapp/feature-overview/custom-tokens.mdx
+++ b/docs/zkapps/writing-a-zkapp/feature-overview/custom-tokens.mdx
@@ -17,6 +17,10 @@ keywords:
   - tokencontract
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 :::info
 
 If you want to create a fungible token you can use the 

--- a/docs/zkapps/writing-a-zkapp/feature-overview/events.mdx
+++ b/docs/zkapps/writing-a-zkapp/feature-overview/events.mdx
@@ -15,6 +15,10 @@ keywords:
   - transaction
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # Events
 
 Events are _public_ arbitrary information that can be passed along with a transaction. If your zkApp allows users to publish a message, for example, those messages could be events.

--- a/docs/zkapps/writing-a-zkapp/feature-overview/fetch-events-and-actions.mdx
+++ b/docs/zkapps/writing-a-zkapp/feature-overview/fetch-events-and-actions.mdx
@@ -15,6 +15,10 @@ keywords:
   - blockchain
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # How to Fetch Events and Actions
 
 [Events](#events) and [Actions](#actions-and-reducer) are two distinct mechanisms for logging information alongside a transaction:

--- a/docs/zkapps/writing-a-zkapp/feature-overview/offchain-storage.mdx
+++ b/docs/zkapps/writing-a-zkapp/feature-overview/offchain-storage.mdx
@@ -15,6 +15,10 @@ keywords:
   - succinctness
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 :::experimental
 
 Offchain storage is currently an experimental feature and is subject to change in the future.

--- a/docs/zkapps/writing-a-zkapp/feature-overview/on-chain-values.mdx
+++ b/docs/zkapps/writing-a-zkapp/feature-overview/on-chain-values.mdx
@@ -13,6 +13,10 @@ keywords:
   - network state
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # On-Chain Values
 
 In a zkApp, you can access the current [on-chain state](/zkapps/writing-a-zkapp/introduction-to-zkapps/how-to-write-a-zkapp#on-chain-state) and many other on-chain values of the account.

--- a/docs/zkapps/writing-a-zkapp/feature-overview/permissions.mdx
+++ b/docs/zkapps/writing-a-zkapp/feature-overview/permissions.mdx
@@ -15,6 +15,10 @@ keywords:
   - authorization
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # Permissions
 
 Permissions are an integral part of zkApp development because they determine who has the authority to interact and make changes to a specific part of a smart contract.

--- a/docs/zkapps/writing-a-zkapp/feature-overview/time-locked-accounts.mdx
+++ b/docs/zkapps/writing-a-zkapp/feature-overview/time-locked-accounts.mdx
@@ -12,6 +12,10 @@ keywords:
   - account timing
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # Time-Locked Accounts
 
 Time-locking allows you to pay someone in MINA or other custom tokens subject to a vesting schedule. Tokens are initially locked and become available for withdrawal only after a certain time or gradually according to a specific schedule.

--- a/docs/zkapps/writing-a-zkapp/feature-overview/upgradability.mdx
+++ b/docs/zkapps/writing-a-zkapp/feature-overview/upgradability.mdx
@@ -14,6 +14,10 @@ keywords:
   - blockchain
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # ZkApp Upgradability
 
 The Mina protocol allows for the upgrading of verification keys on-chain.  This article will demonstrate how to upgrade a ZkApp.

--- a/docs/zkapps/writing-a-zkapp/index.mdx
+++ b/docs/zkapps/writing-a-zkapp/index.mdx
@@ -13,6 +13,11 @@ keywords:
   - quickstart zkapps
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
+
 # zkApps Overview
 
 <br />

--- a/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/getting-started-zkapps.mdx
+++ b/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/getting-started-zkapps.mdx
@@ -13,6 +13,10 @@ keywords:
   - quickstart zkapps
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # zkApps Getting Started
 
 You can start writing zkApps with just a few steps. The focus of this Getting Started Guide is a high-level workflow to build and deploy quickly.

--- a/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/how-to-deploy-a-zkapp.mdx
+++ b/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/how-to-deploy-a-zkapp.mdx
@@ -9,6 +9,10 @@ keywords:
   - configure a zkapp
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # How to Deploy a zkApp
 
 Before deploying, you must first define a few settings, such as which network you are deploying your zkApp to.

--- a/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/how-to-write-a-zkapp-ui.mdx
+++ b/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/how-to-write-a-zkapp-ui.mdx
@@ -13,6 +13,10 @@ keywords:
   - Auro Wallet
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # How to Write a zkApp UI
 
 A zkApp consists of a smart contract and a UI to interact with it. To allow users to interact with your smart contract in a web browser, you typically want to build a website UI.

--- a/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/how-to-write-a-zkapp.mdx
+++ b/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/how-to-write-a-zkapp.mdx
@@ -11,6 +11,10 @@ keywords:
   - zero knowledge proofs
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # How to Write a zkApp
 
 A zkApp consists of a smart contract and a UI to interact with it.

--- a/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/how-zkapps-work.mdx
+++ b/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/how-zkapps-work.mdx
@@ -14,6 +14,10 @@ keywords:
   - off-chain state
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # How zkApps Work
 
 zkApps run in the latest versions of [Chrome](https://www.google.com/chrome/index.html), [Firefox](https://www.mozilla.org/en-US/firefox/new/), [Edge](https://microsoft.com/edge), and [Brave](https://brave.com/) web browsers.

--- a/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/install-zkapp-cli.mdx
+++ b/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/install-zkapp-cli.mdx
@@ -10,6 +10,10 @@ keywords:
   - install zkApp CLI
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # zkApp CLI Installation
 
 Install and use the zkApp CLI to scaffold, write, test, and deploy zkApps (zero knowledge apps) for Mina Protocol using recommended best practices.

--- a/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/interact-with-mina.mdx
+++ b/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/interact-with-mina.mdx
@@ -19,6 +19,11 @@ keywords:
   - authorization types
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
+
 # Interacting With Mina
 
 Now that you know about writing zkApp methods, it's time to learn how users can call these methods.

--- a/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/secure-zkapps.mdx
+++ b/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/secure-zkapps.mdx
@@ -11,6 +11,10 @@ keywords:
   - zero knowledge proofs
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # Security and zkApps
 
 On this page, you will find guidance for how to think about security when building zkApps. We also provide a list of best practices and common pitfalls to help you avoid vulnerabilities.

--- a/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/smart-contracts.mdx
+++ b/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/smart-contracts.mdx
@@ -18,6 +18,10 @@ keywords:
   - on-chain state
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # Smart Contracts
 
 You write smart contracts by extending the base class `SmartContract`:

--- a/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-lightnet.mdx
+++ b/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-lightnet.mdx
@@ -10,6 +10,10 @@ keywords:
   - using zk lightnet
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 :::caution
 
 Use of the **Lightnet** is appropriate for the **local development and testing** only. It is **not** intended to replicate all aspects of the real public networks.

--- a/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-locally.mdx
+++ b/docs/zkapps/writing-a-zkapp/introduction-to-zkapps/testing-zkapps-locally.mdx
@@ -11,6 +11,10 @@ keywords:
   - Docker test
 ---
 
+import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
+
+<MigrateBanner />
+
 # Testing zkApps Locally
 
 Before you can test your zkApps, create automated tests for your smart contract and test with a simulated local blockchain. Test automation is essential to ensure your code is well-tested during development.

--- a/src/components/snippets/migrate-banner.mdx
+++ b/src/components/snippets/migrate-banner.mdx
@@ -1,0 +1,5 @@
+import Admonition from '@theme/Admonition';
+
+<Admonition type="info" title="New Home!">
+  🚀 o1js reference documentation is now available at the new [o1Labs docs site](https://docs.o1labs.org/o1js).
+</Admonition>


### PR DESCRIPTION
Every change ought to be adding 

```tsx
import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';

<MigrateBanner />
```

to the top of a file, or defining the snippet:

```tsx
import Admonition from '@theme/Admonition';

<Admonition type="info" title="New Home!">
  🚀 o1js reference documentation is now available at the new [o1Labs docs site](https://docs.o1labs.org/o1js).
</Admonition>
```