### PR TITLE
docs(mesa): add ADX to the hardware table, correct the seed libp2p keypair guidance

### DIFF
--- a/docs/network-upgrades/mesa/requirements.mdx
+++ b/docs/network-upgrades/mesa/requirements.mdx
@@ -18,9 +18,9 @@ Please note the following are the hardware requirements for each node type after
 
 | Node Type | Memory | CPU | Storage | Network |
 |--|--|--|--|--|
-| Mina Daemon Node | 32 GB RAM | 8 core processor with BMI2 and AVX CPU instruction set are required | 16 GB | 1 Mbps Internet Connection |
+| Mina Daemon Node | 32 GB RAM | 8 core processor with BMI2, ADX and AVX CPU instruction sets are required | 16 GB | 1 Mbps Internet Connection |
 | SNARK Coordinator | 32 GB RAM | 8 core processor | 16 GB | 1 Mbps Internet Connection |
-| SNARK Worker (per worker) | 8 GB RAM | 6 core/12 threads with BMI2 and AVX CPU instruction set are required | 1 GB | 1 Mbps Internet Connection |
+| SNARK Worker (per worker) | 8 GB RAM | 6 core/12 threads with BMI2, ADX and AVX CPU instruction sets are required | 1 GB | 1 Mbps Internet Connection |
 | Archive Node | 32 GB RAM | 8 core processor | 64 GB | 1 Mbps Internet Connection |
 | Rosetta API standalone Docker image | 8 GB RAM | 2 core processor | 16 GB | 1 Mbps Internet Connection |
 | Rosetta API + Archive Node | 32 GB RAM | 8 core processor | 64 GB | 1 Mbps Internet Connection |
@@ -39,8 +39,9 @@ The hardware table above is Mesa-specific; everything else lives once in the Val
 
 ### Generation of libp2p keypair
 
-To ensure connectivity across the network, it is essential that all seed nodes start with the **same** `libp2p` keypair.
-This consistency allows other nodes in the network to reliably connect.
+To ensure connectivity across the network, it is essential that each seed node starts with its own **stable** `libp2p` keypair.
+A keypair determines the peer ID of the node, so each seed node needs a different keypair, and that keypair must stay the same across restarts.
+This stability allows other nodes in the network to reliably connect to the addresses in the published seed list.
 Although the same libp2p keys can be reused from before the upgrade, if you need to manually generate new libp2p keys, use the following command:
 
 ```
@@ -55,7 +56,7 @@ Before the fork, each actor type must complete specific preparations. Complete t
 
 ### All operators
 
-- Verify your hardware meets the [requirements](#hardware-requirements) above (32 GB RAM, 8-core CPU with AVX/BMI2).
+- Verify your hardware meets the [requirements](#hardware-requirements) above (32 GB RAM, 8-core CPU with BMI2, ADX and AVX).
 - Back up your keys and configuration before installing any new packages.
 
 ### Block Producers
@@ -90,4 +91,5 @@ Before the fork, each actor type must complete specific preparations. Complete t
 
 - Update to the Mesa-compatible o1js version (`o1js@3.0.0-mesa.rc2` for the Mesa Trail chain).
 - Recompile your contracts and verify them on the [Mesa Trail test network](/network-upgrades/mesa/mesa-trail).
-- Plan to redeploy every zkApp on Mesa — each must be redeployed because the protocol version bump changes the verification key. {/* TODO(PR #1133): Link to the official o1js Mesa upgrade guide once published (cjjdespres #3220525842). */}
+- Plan to redeploy every zkApp on Mesa — each must be redeployed because the protocol version bump changes the verification key.
+  Your zkApp account and its on-chain state carry over to Mesa automatically, including the state fields at indexes `0-7`. The redeploy replaces the verification key; it does not reset your state. {/* TODO(PR #1133): Link to the official o1js Mesa upgrade guide once published (cjjdespres #3220525842). */}

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -5177,9 +5177,9 @@ Please note the following are the hardware requirements for each node type after
 
 | Node Type | Memory | CPU | Storage | Network |
 |--|--|--|--|--|
-| Mina Daemon Node | 32 GB RAM | 8 core processor with BMI2 and AVX CPU instruction set are required | 16 GB | 1 Mbps Internet Connection |
+| Mina Daemon Node | 32 GB RAM | 8 core processor with BMI2, ADX and AVX CPU instruction sets are required | 16 GB | 1 Mbps Internet Connection |
 | SNARK Coordinator | 32 GB RAM | 8 core processor | 16 GB | 1 Mbps Internet Connection |
-| SNARK Worker (per worker) | 8 GB RAM | 6 core/12 threads with BMI2 and AVX CPU instruction set are required | 1 GB | 1 Mbps Internet Connection |
+| SNARK Worker (per worker) | 8 GB RAM | 6 core/12 threads with BMI2, ADX and AVX CPU instruction sets are required | 1 GB | 1 Mbps Internet Connection |
 | Archive Node | 32 GB RAM | 8 core processor | 64 GB | 1 Mbps Internet Connection |
 | Rosetta API standalone Docker image | 8 GB RAM | 2 core processor | 16 GB | 1 Mbps Internet Connection |
 | Rosetta API + Archive Node | 32 GB RAM | 8 core processor | 64 GB | 1 Mbps Internet Connection |
@@ -5198,8 +5198,9 @@ The hardware table above is Mesa-specific; everything else lives once in the Val
 
 ### Generation of libp2p keypair
 
-To ensure connectivity across the network, it is essential that all seed nodes start with the **same** `libp2p` keypair.
-This consistency allows other nodes in the network to reliably connect.
+To ensure connectivity across the network, it is essential that each seed node starts with its own **stable** `libp2p` keypair.
+A keypair determines the peer ID of the node, so each seed node needs a different keypair, and that keypair must stay the same across restarts.
+This stability allows other nodes in the network to reliably connect to the addresses in the published seed list.
 Although the same libp2p keys can be reused from before the upgrade, if you need to manually generate new libp2p keys, use the following command:
 
 ```
@@ -5214,7 +5215,7 @@ Before the fork, each actor type must complete specific preparations. Complete t
 
 ### All operators
 
-- Verify your hardware meets the [requirements](#hardware-requirements) above (32 GB RAM, 8-core CPU with AVX/BMI2).
+- Verify your hardware meets the [requirements](#hardware-requirements) above (32 GB RAM, 8-core CPU with BMI2, ADX and AVX).
 - Back up your keys and configuration before installing any new packages.
 
 ### Block Producers
@@ -5249,7 +5250,8 @@ Before the fork, each actor type must complete specific preparations. Complete t
 
 - Update to the Mesa-compatible o1js version (`o1js@3.0.0-mesa.rc2` for the Mesa Trail chain).
 - Recompile your contracts and verify them on the [Mesa Trail test network](/network-upgrades/mesa/mesa-trail).
-- Plan to redeploy every zkApp on Mesa — each must be redeployed because the protocol version bump changes the verification key. {/* TODO(PR #1133): Link to the official o1js Mesa upgrade guide once published (cjjdespres #3220525842). */}
+- Plan to redeploy every zkApp on Mesa — each must be redeployed because the protocol version bump changes the verification key.
+  Your zkApp account and its on-chain state carry over to Mesa automatically, including the state fields at indexes `0-7`. The redeploy replaces the verification key; it does not reset your state. {/* TODO(PR #1133): Link to the official o1js Mesa upgrade guide once published (cjjdespres #3220525842). */}
 
 ---
 url: /network-upgrades/mesa/troubleshooting


### PR DESCRIPTION
Table E of `mesa-tracker-fix-implementation_v3.txt` (25 Aug 2026). Companion to **MinaProtocol/mesa-upgrade-status#37**, which fixes the same hardware string on the upgrade tracker. The tracker copied its wording from this page, so the tracker fix (A1) is only half the correction without E1 here.

All of it is on `docs/network-upgrades/mesa/requirements.mdx`.

## E1 — the CPU instruction set list is incomplete

Mesa needs **BMI2, ADX and AVX**. `ADX` was missing in all three places:

- the **Mina Daemon Node** row of the hardware table
- the **SNARK Worker (per worker)** row
- the **All operators** checklist line, which also used the `AVX/BMI2` short form

## E4 — seed nodes must not share a libp2p keypair

The page said that all seed nodes must start with the **same** `libp2p` keypair. That is wrong. A libp2p keypair determines the peer ID of the node, so seed nodes cannot share one.

The published seed lists confirm it — every entry carries a distinct peer ID:

```
$ curl -s https://bootnodes.minaprotocol.com/networks/devnet.txt  | grep -o 'p2p/[A-Za-z0-9]*' | sort -u | wc -l
3      # of 3 entries
$ curl -s https://bootnodes.minaprotocol.com/networks/mainnet.txt | grep -o 'p2p/[A-Za-z0-9]*' | sort -u | wc -l
11     # of 11 entries
```

The dedicated page, `node-operators/seed-peers/generating-a-libp2p-keypair`, already says **stable**, not **same**. This page now agrees with it: each seed node needs its own keypair, and that keypair must not change across restarts.

## E3 — partial

The zkApp checklist said only that every zkApp must be redeployed, which reads as though on-chain state is lost. It is not. `network-upgrades/mesa/upgrade-steps/examples.mdx` already states that the account and its state fields at indexes `0-7` carry over, and that only the Berkeley verification key becomes invalid. That fact is now on the checklist too.

**This does not close E3.** Whether a redeploy is required at all, or whether a verification key update is enough, is still an open question for the o1js owner.

## Not in this PR

| Ref | Why |
|---|---|
| **E2** | This page says 16 GB storage for the daemon and the SNARK coordinator, 1 GB for the SNARK worker, and 8 GB RAM per worker. The upgrade blog and the devnet operator document give 64 GB, and ~4 GB per SNARK **process**. I cannot tell which side is right, and wrong hardware figures on an operator page are worse than none. **Needs the docs owner.** |
| **E5** | No change needed. This page uses `--privkey-path`, which matches the flag declared at `src/lib/cli_lib/flag.ml:22` in the mina repo. The single-dash `-privkey-path` form is the one in the source docs, not here. |

Also noted: `docs/network-upgrades/berkeley/requirements.mdx:59` carries the same wrong "same libp2p keypair" sentence. It is a historical upgrade page, so I left it for the docs owner to decide.

## Verification

- `static/llms-full.txt` regenerated, as `npm run check-llms-txt` requires. `static/llms.txt` is unchanged, because no frontmatter changed
- Full `docusaurus build` passes. The broken anchor warnings come from the mesa index page and are pre-existing
- `AVX/BMI2` no longer appears anywhere under `docs/` or `static/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)