### PR TITLE
chore: migrate gsutil to gcloud storage

### DIFF
--- a/docs/network-upgrades/berkeley/archive-migration/archive-migration-installation.mdx
+++ b/docs/network-upgrades/berkeley/archive-migration/archive-migration-installation.mdx
@@ -20,7 +20,7 @@ To mitigate these limitations, the archive node maintenance package is available
 
 ## Install with Google Cloud SDK
 
-The Google Cloud SDK installer does not always register a `google-cloud-sdk` apt package. The best way to install gsutil is using the apt repostory:
+The Google Cloud SDK installer does not always register a `google-cloud-sdk` apt package. The best way to install the Google Cloud CLI is using the apt repostory:
 
 ```sh
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
@@ -32,7 +32,7 @@ sudo apt-get update && sudo apt-get install google-cloud-sdk
 
 We strongly encourage you to perform the migration on your own data to preserve the benefits of decentralization. However, if you want to use the archive data that o1labs runs (for example, to bootstrap a new archive from SQL without waiting all day for the chain to download and replay), you can use the following steps:
 
-1. Download the Devnet/Mainnet archive data using cURL or gsutil:
+1. Download the Devnet/Mainnet archive data using cURL or gcloud storage:
 
     - cURL:
 
@@ -50,10 +50,10 @@ We strongly encourage you to perform the migration on your own data to preserve 
 
      :warning: The majority of backups have the `0000` suffix. If a download with that name suffix is not available, try incrementing it. For example, `0001`, `0002`, and so on.
 
-    - gsutil:
+    - gcloud storage:
 
        ```sh
-       gsutil cp gs://mina-archive-dumps/mainnet-archive-dump-2024-01-15* .
+       gcloud storage cp gs://mina-archive-dumps/mainnet-archive-dump-2024-01-15* .
        ```
 
 2. Extract the tar package.
@@ -78,7 +78,7 @@ We strongly encourage you to perform the migration on your own data to preserve 
 
 The recommended method is to perform migration on your own data to preserve the benefits of decentralization.
 
-`gsutil cp gs://mina_network_block_data/{network}-*.json .`
+`gcloud storage cp gs://mina_network_block_data/{network}-*.json .`
 
 :warning: Precomputed blocks for the Mainnet network take ~800 GB of disk space. Plan for adequate time to download these blocks. The Berkeley migration app downloads them incrementally only when needed.
 

--- a/docs/network-upgrades/berkeley/archive-migration/archive-migration-prerequisites.mdx
+++ b/docs/network-upgrades/berkeley/archive-migration/archive-migration-prerequisites.mdx
@@ -19,7 +19,7 @@ To successfully migrate the archive database into the Berkeley version of the Mi
 
 - PostgreSQL database for database server
 - If you use Docker, then any of the supported OS by Mina (bullseye, focal, or buster) with at least 32 GB of RAM
-- gsutil application from Google Cloud Suite in version 5 or later
+- Google Cloud CLI (`gcloud`), which provides the `gcloud storage` commands
 - (Optional) Docker in version 23.0 or later
 
 ## (Optional) Devnet/Mainnet database 
@@ -40,25 +40,37 @@ However, it is strongly recommended that you perform migration on your own data 
 For Devnet blocks:
 
 ```sh
-gsutil cp gs://mina_network_block_data/devnet-*.json .
+gcloud storage cp gs://mina_network_block_data/devnet-*.json .
 ```
 
 For Mainnet blocks:
 
 ```sh
-gsutil cp gs://mina_network_block_data/mainnet-*.json .
+gcloud storage cp gs://mina_network_block_data/mainnet-*.json .
 ```
 
 :warning: Precomputed blocks for the Mainnet network take ~800 GB of disk space. Plan for adequate time to download these blocks. The Berkeley migration app downloads them incrementally only when needed. You can instead download a 100 GB bundle of only the canonical Mainnet blocks that unpacks into ~220 GB: 
 
 ```sh
-gsutil cp gs://mina_network_block_data/mainnet-bundle-2024-03-20.tar.zst . ; tar -xf mainnet-bundle-2024-03-20.tar.zst
+gcloud storage cp gs://mina_network_block_data/mainnet-bundle-2024-03-20.tar.zst . ; tar -xf mainnet-bundle-2024-03-20.tar.zst
+```
+
+Or, without the Google Cloud CLI, over HTTPS:
+
+```sh
+wget https://storage.googleapis.com/mina_network_block_data/mainnet-bundle-2024-03-20.tar.zst ; tar -xf mainnet-bundle-2024-03-20.tar.zst
 ```
 
 :warning: Precomputed blocks for the Devnet network take several hundred GBs. Plan for adequate time to download these blocks. Instead, you can download a ~50 GB bundle of only the canonical Devnet blocks that unpacks into ~90 GB:
 
 ```sh
-gsutil cp gs://mina_network_block_data/devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz . ; tar -xf devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz
+gcloud storage cp gs://mina_network_block_data/devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz . ; tar -xf devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz
+```
+
+Or, without the Google Cloud CLI, over HTTPS:
+
+```sh
+wget https://storage.googleapis.com/mina_network_block_data/devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz ; tar -xf devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz
 ```
 
 These bundles are partial. Updated documentation with the new links and final data will be provided _after_ the Berkeley major upgrade is completed.

--- a/docs/network-upgrades/berkeley/archive-migration/debian-example.mdx
+++ b/docs/network-upgrades/berkeley/archive-migration/debian-example.mdx
@@ -17,6 +17,8 @@ You can follow these steps that can be copy-pasted directly into a fresh Debian 
 
 This example uses an altered two-step version of the [full simplified workflow](/network-upgrades/berkeley/archive-migration/migrating-archive-database-to-berkeley#simplified-approach).
 
+If you would rather not install the Google Cloud CLI, every `gcloud storage cp gs://<bucket>/<object> .` below can be replaced with `wget https://storage.googleapis.com/<bucket>/<object>`.
+
 ```sh
 apt update && apt install lsb-release sudo postgresql curl wget gpg # debian:11 is surprisingly light
 
@@ -31,7 +33,7 @@ sudo apt-get update && sudo apt-get install --allow-downgrades -y mina-archive-m
 mkdir -p mina-migration-workdir
 cd mina-migration-workdir
 
-gsutil cp gs://mina_network_block_data/devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz .
+gcloud storage cp gs://mina_network_block_data/devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz .
 tar -xf devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz
 
 wget https://raw.githubusercontent.com/MinaProtocol/mina/berkeley/src/app/archive/create_schema.sql
@@ -43,7 +45,7 @@ createdb devnet_really_migrated
 
 psql -d devnet_really_migrated -f create_schema.sql
 
-gsutil cp gs://mina-archive-dumps/devnet-archive-dump-2024-03-22_0000.sql.tar.gz .
+gcloud storage cp gs://mina-archive-dumps/devnet-archive-dump-2024-03-22_0000.sql.tar.gz .
 tar -xf devnet-archive-dump-2024-03-22_0000.sql.tar.gz
 # the next step ensures you don't accidentally merge mainnet and devnet data
 sed -i -e s/archive_balances_migrated/devnet_balances_migrated/g devnet-archive-dump-2024-03-22_0000.sql
@@ -58,7 +60,7 @@ mina-berkeley-migration-script initial \
 
 # now, do a final migration
 
-gsutil cp gs://mina-archive-dumps/devnet-archive-dump-2024-03-22_2050.sql.tar.gz .
+gcloud storage cp gs://mina-archive-dumps/devnet-archive-dump-2024-03-22_2050.sql.tar.gz .
 tar -xf devnet-archive-dump-2024-03-22_2050.sql.tar.gz
 # the next step ensures you don't accidentally merge mainnet and devnet data
 sed -i -e s/archive_balances_migrated/devnet_balances_migrated/g devnet-archive-dump-2024-03-22_2050.sql

--- a/docs/network-upgrades/mesa/archive-upgrade.mdx
+++ b/docs/network-upgrades/mesa/archive-upgrade.mdx
@@ -63,7 +63,7 @@ To successfully upgrade the archive database to Mesa, you must ensure that your 
 
 - PostgreSQL database for database server
 - If you use Docker, then any of the supported OS by Mina (bullseye, focal, noble, bookworm or jammy) with at least 32 GB of RAM
-- gsutil application from Google Cloud Suite in version 5 or later
+- Google Cloud CLI (`gcloud`), which provides the `gcloud storage` commands
 - (Optional) Docker in version 23.0 or later
 
 ## Archive database

--- a/docs/network-upgrades/mesa/mesa-trail.mdx
+++ b/docs/network-upgrades/mesa/mesa-trail.mdx
@@ -243,9 +243,9 @@ Precomputed blocks are published to the `mesa-rc-precomputed-blocks` bucket, one
 
 ```bash
 # List recent blocks
-gsutil ls gs://mesa-rc-precomputed-blocks/ | tail
+gcloud storage ls gs://mesa-rc-precomputed-blocks/ | tail
 
-# Fetch a single block over HTTPS (no gsutil required)
+# Fetch a single block over HTTPS (no Google Cloud CLI required)
 curl -O https://storage.googleapis.com/mesa-rc-precomputed-blocks/mina-mesa-rc-1-<height>-<state-hash>.json
 ```
 
@@ -257,7 +257,7 @@ Hourly archive dumps are published to the `mina-archive-dumps` bucket with the p
 
 ```bash
 # List available dumps
-gsutil ls gs://mina-archive-dumps/mina-mesa-rc-1-archive-dump-*
+gcloud storage ls gs://mina-archive-dumps/mina-mesa-rc-1-archive-dump-*
 
 # Download and restore the latest dump
 curl -O https://storage.googleapis.com/mina-archive-dumps/mina-mesa-rc-1-archive-dump-<YYYY-MM-DD>_<HHMM>.sql.tar.gz

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -2302,7 +2302,7 @@ To mitigate these limitations, the archive node maintenance package is available
 
 ## Install with Google Cloud SDK
 
-The Google Cloud SDK installer does not always register a `google-cloud-sdk` apt package. The best way to install gsutil is using the apt repostory:
+The Google Cloud SDK installer does not always register a `google-cloud-sdk` apt package. The best way to install the Google Cloud CLI is using the apt repostory:
 
 ```sh
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
@@ -2314,7 +2314,7 @@ sudo apt-get update && sudo apt-get install google-cloud-sdk
 
 We strongly encourage you to perform the migration on your own data to preserve the benefits of decentralization. However, if you want to use the archive data that o1labs runs (for example, to bootstrap a new archive from SQL without waiting all day for the chain to download and replay), you can use the following steps:
 
-1. Download the Devnet/Mainnet archive data using cURL or gsutil:
+1. Download the Devnet/Mainnet archive data using cURL or gcloud storage:
 
     - cURL:
 
@@ -2332,10 +2332,10 @@ We strongly encourage you to perform the migration on your own data to preserve 
 
      :warning: The majority of backups have the `0000` suffix. If a download with that name suffix is not available, try incrementing it. For example, `0001`, `0002`, and so on.
 
-    - gsutil:
+    - gcloud storage:
 
        ```sh
-       gsutil cp gs://mina-archive-dumps/mainnet-archive-dump-2024-01-15* .
+       gcloud storage cp gs://mina-archive-dumps/mainnet-archive-dump-2024-01-15* .
        ```
 
 2. Extract the tar package.
@@ -2360,7 +2360,7 @@ We strongly encourage you to perform the migration on your own data to preserve 
 
 The recommended method is to perform migration on your own data to preserve the benefits of decentralization.
 
-`gsutil cp gs://mina_network_block_data/{network}-*.json .`
+`gcloud storage cp gs://mina_network_block_data/{network}-*.json .`
 
 :warning: Precomputed blocks for the Mainnet network take ~800 GB of disk space. Plan for adequate time to download these blocks. The Berkeley migration app downloads them incrementally only when needed.
 
@@ -2442,7 +2442,7 @@ To successfully migrate the archive database into the Berkeley version of the Mi
 
 - PostgreSQL database for database server
 - If you use Docker, then any of the supported OS by Mina (bullseye, focal, or buster) with at least 32 GB of RAM
-- gsutil application from Google Cloud Suite in version 5 or later
+- Google Cloud CLI (`gcloud`), which provides the `gcloud storage` commands
 - (Optional) Docker in version 23.0 or later
 
 ## (Optional) Devnet/Mainnet database 
@@ -2463,25 +2463,37 @@ However, it is strongly recommended that you perform migration on your own data 
 For Devnet blocks:
 
 ```sh
-gsutil cp gs://mina_network_block_data/devnet-*.json .
+gcloud storage cp gs://mina_network_block_data/devnet-*.json .
 ```
 
 For Mainnet blocks:
 
 ```sh
-gsutil cp gs://mina_network_block_data/mainnet-*.json .
+gcloud storage cp gs://mina_network_block_data/mainnet-*.json .
 ```
 
 :warning: Precomputed blocks for the Mainnet network take ~800 GB of disk space. Plan for adequate time to download these blocks. The Berkeley migration app downloads them incrementally only when needed. You can instead download a 100 GB bundle of only the canonical Mainnet blocks that unpacks into ~220 GB: 
 
 ```sh
-gsutil cp gs://mina_network_block_data/mainnet-bundle-2024-03-20.tar.zst . ; tar -xf mainnet-bundle-2024-03-20.tar.zst
+gcloud storage cp gs://mina_network_block_data/mainnet-bundle-2024-03-20.tar.zst . ; tar -xf mainnet-bundle-2024-03-20.tar.zst
+```
+
+Or, without the Google Cloud CLI, over HTTPS:
+
+```sh
+wget https://storage.googleapis.com/mina_network_block_data/mainnet-bundle-2024-03-20.tar.zst ; tar -xf mainnet-bundle-2024-03-20.tar.zst
 ```
 
 :warning: Precomputed blocks for the Devnet network take several hundred GBs. Plan for adequate time to download these blocks. Instead, you can download a ~50 GB bundle of only the canonical Devnet blocks that unpacks into ~90 GB:
 
 ```sh
-gsutil cp gs://mina_network_block_data/devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz . ; tar -xf devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz
+gcloud storage cp gs://mina_network_block_data/devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz . ; tar -xf devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz
+```
+
+Or, without the Google Cloud CLI, over HTTPS:
+
+```sh
+wget https://storage.googleapis.com/mina_network_block_data/devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz ; tar -xf devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz
 ```
 
 These bundles are partial. Updated documentation with the new links and final data will be provided _after_ the Berkeley major upgrade is completed.
@@ -2498,6 +2510,8 @@ You can follow these steps that can be copy-pasted directly into a fresh Debian 
 
 This example uses an altered two-step version of the [full simplified workflow](/network-upgrades/berkeley/archive-migration/migrating-archive-database-to-berkeley#simplified-approach).
 
+If you would rather not install the Google Cloud CLI, every `gcloud storage cp gs://<bucket>/<object> .` below can be replaced with `wget https://storage.googleapis.com/<bucket>/<object>`.
+
 ```sh
 apt update && apt install lsb-release sudo postgresql curl wget gpg # debian:11 is surprisingly light
 
@@ -2512,7 +2526,7 @@ sudo apt-get update && sudo apt-get install --allow-downgrades -y mina-archive-m
 mkdir -p mina-migration-workdir
 cd mina-migration-workdir
 
-gsutil cp gs://mina_network_block_data/devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz .
+gcloud storage cp gs://mina_network_block_data/devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz .
 tar -xf devnet-bundle-3NKRsRWBzmPR8Z8ZmJb4u8FLpnSkjRitUpKZzVkHp11QuwP5i839.tar.gz
 
 wget https://raw.githubusercontent.com/MinaProtocol/mina/berkeley/src/app/archive/create_schema.sql
@@ -2524,7 +2538,7 @@ createdb devnet_really_migrated
 
 psql -d devnet_really_migrated -f create_schema.sql
 
-gsutil cp gs://mina-archive-dumps/devnet-archive-dump-2024-03-22_0000.sql.tar.gz .
+gcloud storage cp gs://mina-archive-dumps/devnet-archive-dump-2024-03-22_0000.sql.tar.gz .
 tar -xf devnet-archive-dump-2024-03-22_0000.sql.tar.gz
 # the next step ensures you don't accidentally merge mainnet and devnet data
 sed -i -e s/archive_balances_migrated/devnet_balances_migrated/g devnet-archive-dump-2024-03-22_0000.sql
@@ -2539,7 +2553,7 @@ mina-berkeley-migration-script initial \
 
 # now, do a final migration
 
-gsutil cp gs://mina-archive-dumps/devnet-archive-dump-2024-03-22_2050.sql.tar.gz .
+gcloud storage cp gs://mina-archive-dumps/devnet-archive-dump-2024-03-22_2050.sql.tar.gz .
 tar -xf devnet-archive-dump-2024-03-22_2050.sql.tar.gz
 # the next step ensures you don't accidentally merge mainnet and devnet data
 sed -i -e s/archive_balances_migrated/devnet_balances_migrated/g devnet-archive-dump-2024-03-22_2050.sql
@@ -4280,7 +4294,7 @@ To successfully upgrade the archive database to Mesa, you must ensure that your 
 
 - PostgreSQL database for database server
 - If you use Docker, then any of the supported OS by Mina (bullseye, focal, noble, bookworm or jammy) with at least 32 GB of RAM
-- gsutil application from Google Cloud Suite in version 5 or later
+- Google Cloud CLI (`gcloud`), which provides the `gcloud storage` commands
 - (Optional) Docker in version 23.0 or later
 
 ## Archive database

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -5141,9 +5141,9 @@ Precomputed blocks are published to the `mesa-rc-precomputed-blocks` bucket, one
 
 ```bash
 # List recent blocks
-gsutil ls gs://mesa-rc-precomputed-blocks/ | tail
+gcloud storage ls gs://mesa-rc-precomputed-blocks/ | tail
 
-# Fetch a single block over HTTPS (no gsutil required)
+# Fetch a single block over HTTPS (no Google Cloud CLI required)
 curl -O https://storage.googleapis.com/mesa-rc-precomputed-blocks/mina-mesa-rc-1-<height>-<state-hash>.json
 ```
 
@@ -5155,7 +5155,7 @@ Hourly archive dumps are published to the `mina-archive-dumps` bucket with the p
 
 ```bash
 # List available dumps
-gsutil ls gs://mina-archive-dumps/mina-mesa-rc-1-archive-dump-*
+gcloud storage ls gs://mina-archive-dumps/mina-mesa-rc-1-archive-dump-*
 
 # Download and restore the latest dump
 curl -O https://storage.googleapis.com/mina-archive-dumps/mina-mesa-rc-1-archive-dump-<YYYY-MM-DD>_<HHMM>.sql.tar.gz


### PR DESCRIPTION
## Why

Google is retiring `gsutil` in **March 2027**, and it is already being dropped from new Cloud SDK bundles. Readers who follow these pages after that date will hit `command not found`. This PR migrates the documented commands to `gcloud storage`, which ships in every current Cloud SDK.

## What changed

**Commands — all 11 call sites were a bare `gsutil cp` or `gsutil ls`, so the swap is exact.** There is no `-m`, `-q`, `-o`, `-h`, `-l`, `-d`, `cat`, `stat`, `du` or `rsync` anywhere in these pages, which means no flag translation, no output-format differences, and no exit-code semantics to audit. `gsutil <verb> <args>` → `gcloud storage <verb> <args>`, arguments untouched.

- `docs/network-upgrades/berkeley/archive-migration/archive-migration-prerequisites.mdx` (4 × `cp`)
- `docs/network-upgrades/berkeley/archive-migration/archive-migration-installation.mdx` (2 × `cp`)
- `docs/network-upgrades/berkeley/archive-migration/debian-example.mdx` (3 × `cp`)
- `docs/network-upgrades/mesa/mesa-trail.mdx` (2 × `ls`) — the live Mesa Trail page. Both are bare `gsutil ls` with no flags: nothing to carry over, and notably no `-d`, which has no `gcloud storage` equivalent and would have needed a rewrite rather than a swap. The adjacent comment on the HTTPS alternative is updated from "no gsutil required" to "no Google Cloud CLI required" so the contrast it draws still matches the command directly above it.

**Prose** — the requirement bullet `gsutil application from Google Cloud Suite in version 5 or later` now names the Google Cloud CLI. The "version 5 or later" qualifier is dropped deliberately: it is a *gsutil* version number with no `gcloud` analogue, so carrying it over would be meaningless.

- `docs/network-upgrades/mesa/archive-upgrade.mdx` (the live upcoming-upgrade page)
- `docs/network-upgrades/berkeley/archive-migration/archive-migration-prerequisites.mdx`
- `docs/network-upgrades/berkeley/archive-migration/archive-migration-installation.mdx` (install lead-in, the cURL/gcloud list label)

**HTTPS alternative surfaced (additive).** These buckets are already publicly readable over `https://storage.googleapis.com/<bucket>/<object>` — a path that is completely immune to the deprecation and needs no Cloud SDK at all. `docker-example.mdx` and `mesa-trail.mdx` already used it. It is now offered alongside the migrated commands on the two pages that previously only had a GCS-CLI path:

- `archive-migration-prerequisites.mdx` — a `wget https://storage.googleapis.com/...` equivalent next to each of the two single-object bundle downloads.
- `debian-example.mdx` — one line noting that every `gcloud storage cp gs://<bucket>/<object> .` in the copy-paste block can be replaced with `wget https://storage.googleapis.com/<bucket>/<object>`.

> **Reviewer note:** the HTTPS URLs added here were constructed by mechanically mapping the already-documented `gs://<bucket>/<object>` paths onto the same pattern used by the existing reference at `docker-example.mdx:45`. They were **not** individually fetched against live storage, so please spot-check them rather than assuming they were verified.

No `gcloud storage` command was removed, no page was restructured, no headings were rewritten. The two wildcard downloads (`devnet-*.json`, `mainnet-*.json`) intentionally get no HTTPS equivalent, because HTTPS object GETs cannot expand a glob — offering one would be wrong.

**`static/llms-full.txt` regenerated** via `node scripts/generate-llms-txt.mjs`, as the `check-llms-txt` workflow requires. Its diff is exactly the mirror of the `docs/` diff and nothing else.

## Deliberately NOT changed

Several prose mentions of `gsutil` remain. Rewriting any of them would state something factually false:

1. **`archive-migration-prerequisites.mdx:30`** — "You can use any gsutil-compatible alternative to Google Cloud or a gsutil wrapper program."
2. **`archive-migration-prerequisites.mdx:37`** — "The **berkeley-migration** app uses the gsutil app to download blocks."
   Lines 30 and 37 describe the **berkeley-migration app's own internals**, not a command the reader types. The OCaml app still shells out to `gsutil`; rewriting these would assert a code change that has not happened. That migration is tracked separately against `MinaProtocol/mina`.
3. **`migrating-archive-database-to-berkeley.mdx:515`** — "you can use any gsutil-compatible storage backend (for example, S3)."
   "gsutil-compatible" here is a term of art meaning **boto/S3 interoperability**. `gcloud storage` is GCS-only and has *no* boto or S3 interop, so swapping the word would silently delete a documented S3 escape hatch for operators not on GCP.
4. **`docs/network-upgrades/mesa/verify-the-release.mdx:85,95,188,219`** — these four describe what the **release-verification script itself** requires and quote a verbatim error string it emits (`Error: gsutil is required when PRECOMPUTED_FORK_BLOCK is nonexistent path`). Same category as items 1–2: the change belongs with the upstream script, and documenting it as already done would be false.

Also untouched, for the record: the apt install blocks in `installation.mdx` and `debian-example.mdx` — they install the Cloud SDK, which still ships `gcloud`. Nothing to fix.

## Verification

- `npm ci && npm run build` — **passes** (exit 0, "Generated static files in build"). This was the main risk: `archive-migration-installation.mdx` contains an inline code span holding `{network}`, which MDX v3 would parse as a JS expression if it ever fell outside backticks. It stays inside backticks and the build confirms it.
  - The only build warnings are four pre-existing broken anchors on `/network-upgrades/mesa` pointing at `glossary#...`. They are present on `main` and unrelated to this change.
- The load-bearing list indentation in `archive-migration-installation.mdx` (4 spaces on the list item, 7 on the nested fence) is preserved byte-for-byte, as is the fence structure in `mesa-trail.mdx`.
- `grep -rn gsutil docs/` afterwards returns only the intentional lines listed above.
- Existing typo `repostory` in `installation.mdx` left in place — out of scope for this PR.
