### PR TITLE
docs(mesa): fill in the real mainnet and devnet fork schedules

### DIFF
--- a/docs/network-upgrades/mesa/fork-schedule.mdx
+++ b/docs/network-upgrades/mesa/fork-schedule.mdx
@@ -25,34 +25,44 @@ The relevant moments are:
 
 ## Mainnet
 
-:::warning Values not yet published
-The mainnet Mesa fork schedule has not been announced. The values below are placeholders. They will be filled in once o1Labs publishes the stop-slot release and the Mesa genesis timestamp.
+:::info Upgrade day is 2026-09-03
+The mainnet stop-slot schedule is published and is compiled into the releases below. Announced in the [3.5.0 Mainnet Stop Slot Release](https://github.com/MinaProtocol/mina/releases/tag/3.5.0-mainnet-stop-slot) and the [4.0.0 Mainnet Automode Upgrade Release](https://github.com/MinaProtocol/mina/releases/tag/4.0.0-mainnet).
 :::
 
-| Field                                   | Value                                                                          |
-| --------------------------------------- | ------------------------------------------------------------------------------ |
-| Pre-fork (stop-slot) release            | _TBD — will be a `3.x.x` tag_                                                  |
-| Mesa release                            | _TBD — will be a `4.x.x` tag_                                                  |
-| `stop-transaction-slot` (`slot_tx_end`) | _TBD_                                                                          |
-| `stop-network-slot` (`slot_chain_end`)  | _TBD_                                                                          |
-| Mesa genesis timestamp (UTC)            | _TBD — exactly 3 hours after the stop-network-slot_                            |
-| State Finalization window               | Exactly 100 slots = exactly 5 hours between `slot_tx_end` and `slot_chain_end` |
+| Field                                   | Value                                                                                                                                                   |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pre-fork (stop-slot) release            | [`3.5.0-mainnet-stop-slot`](https://github.com/MinaProtocol/mina/releases/tag/3.5.0-mainnet-stop-slot) — `mina-mainnet=3.5.0-mainnet-stop-slot-5e100ee` |
+| Automode release                        | [`4.0.0-mainnet`](https://github.com/MinaProtocol/mina/releases/tag/4.0.0-mainnet) — `mina-mainnet-automode=4.0.0-mainnet-893c877`                      |
+| Mesa release (manual mode only)         | _Published after the stop-network-slot_                                                                                                                 |
+| `stop-transaction-slot` (`slot_tx_end`) | Slot **393800** — 2026-09-03 10:00 UTC                                                                                                                  |
+| `stop-network-slot` (`slot_chain_end`)  | Slot **393900** — 2026-09-03 15:00 UTC                                                                                                                  |
+| Mesa genesis timestamp (UTC)            | 2026-09-03 18:00 (`hard_fork_genesis_slot_delta` = 60 slots = 3 hours)                                                                                  |
+| State Finalization window               | Exactly 100 slots = exactly 5 hours between `slot_tx_end` and `slot_chain_end`                                                                          |
 
-Subscribe to the [MinaProtocol/mina releases](https://github.com/MinaProtocol/mina/releases?q=mesa) and watch the [Mina Foundation announcements channel](https://discord.gg/minaprotocol) for the schedule publication.
+Both mainnet packages come from the `stable` channel on `packages.o1test.net`. Run **one** of the two releases:
+
+- **Automode** — install `mina-mainnet-automode=4.0.0-mainnet-893c877` before the stop-transaction-slot. The dispatcher swaps to the Mesa binary by itself. No second upgrade.
+- **Manual** — install `mina-mainnet=3.5.0-mainnet-stop-slot-5e100ee` before the stop-transaction-slot, keep it running until the stop-network-slot, then install the Mesa release when it is published. See [Upgrade Modes](/network-upgrades/mesa/upgrade-modes).
+
+The archive package for both paths is `mina-archive=3.5.0-mainnet-stop-slot-5e100ee`.
 
 ## Devnet
 
-:::warning Values not yet published
-Devnet typically forks ahead of mainnet to give integrators a final dress rehearsal. Schedule will be posted here once announced.
+:::note Devnet forked on 2026-08-19
+Devnet is on Mesa. The values below are historical; they will not change.
 :::
 
-| Field                                   | Value |
-| --------------------------------------- | ----- |
-| Pre-fork (stop-slot) release            | _TBD_ |
-| Mesa release                            | _TBD_ |
-| `stop-transaction-slot` (`slot_tx_end`) | _TBD_ |
-| `stop-network-slot` (`slot_chain_end`)  | _TBD_ |
-| Mesa genesis timestamp (UTC)            | _TBD_ |
+| Field                                   | Value                                                                                                                                               |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pre-fork (stop-slot) release            | [`3.5.0-devnet-stop-slot`](https://github.com/MinaProtocol/mina/releases/tag/3.5.0-devnet-stop-slot) — `mina-devnet=3.5.0-devnet-stop-slot-849edfa` |
+| Automode release                        | [`4.0.0-devnet`](https://github.com/MinaProtocol/mina/releases/tag/4.0.0-devnet) — `mina-devnet-automode=4.0.0-devnet-2dc9218`                      |
+| Mesa release (manual mode only)         | [`4.0.0-devnet-mesa`](https://github.com/MinaProtocol/mina/releases/tag/4.0.0-devnet-mesa) — `mina-devnet=4.0.0-6965b50`                            |
+| `stop-transaction-slot` (`slot_tx_end`) | Slot **413540** — 2026-08-19 10:00 UTC                                                                                                              |
+| `stop-network-slot` (`slot_chain_end`)  | Slot **413640** — 2026-08-19 15:00 UTC                                                                                                              |
+| Mesa genesis timestamp (UTC)            | 2026-08-19 18:00                                                                                                                                    |
+| State Finalization window               | Exactly 100 slots = exactly 5 hours between `slot_tx_end` and `slot_chain_end`                                                                      |
+
+Devnet packages come from the `alpha` channel on `packages.o1test.net`. A node that joins devnet now must use `mina-devnet=4.0.0-6965b50`; the two pre-fork releases can no longer connect.
 
 ## Preflight (archived)
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -4583,34 +4583,44 @@ The relevant moments are:
 
 ## Mainnet
 
-:::warning Values not yet published
-The mainnet Mesa fork schedule has not been announced. The values below are placeholders. They will be filled in once o1Labs publishes the stop-slot release and the Mesa genesis timestamp.
+:::info Upgrade day is 2026-09-03
+The mainnet stop-slot schedule is published and is compiled into the releases below. Announced in the [3.5.0 Mainnet Stop Slot Release](https://github.com/MinaProtocol/mina/releases/tag/3.5.0-mainnet-stop-slot) and the [4.0.0 Mainnet Automode Upgrade Release](https://github.com/MinaProtocol/mina/releases/tag/4.0.0-mainnet).
 :::
 
-| Field                                   | Value                                                                          |
-| --------------------------------------- | ------------------------------------------------------------------------------ |
-| Pre-fork (stop-slot) release            | _TBD — will be a `3.x.x` tag_                                                  |
-| Mesa release                            | _TBD — will be a `4.x.x` tag_                                                  |
-| `stop-transaction-slot` (`slot_tx_end`) | _TBD_                                                                          |
-| `stop-network-slot` (`slot_chain_end`)  | _TBD_                                                                          |
-| Mesa genesis timestamp (UTC)            | _TBD — exactly 3 hours after the stop-network-slot_                            |
-| State Finalization window               | Exactly 100 slots = exactly 5 hours between `slot_tx_end` and `slot_chain_end` |
+| Field                                   | Value                                                                                                                                                   |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pre-fork (stop-slot) release            | [`3.5.0-mainnet-stop-slot`](https://github.com/MinaProtocol/mina/releases/tag/3.5.0-mainnet-stop-slot) — `mina-mainnet=3.5.0-mainnet-stop-slot-5e100ee` |
+| Automode release                        | [`4.0.0-mainnet`](https://github.com/MinaProtocol/mina/releases/tag/4.0.0-mainnet) — `mina-mainnet-automode=4.0.0-mainnet-893c877`                      |
+| Mesa release (manual mode only)         | _Published after the stop-network-slot_                                                                                                                 |
+| `stop-transaction-slot` (`slot_tx_end`) | Slot **393800** — 2026-09-03 10:00 UTC                                                                                                                  |
+| `stop-network-slot` (`slot_chain_end`)  | Slot **393900** — 2026-09-03 15:00 UTC                                                                                                                  |
+| Mesa genesis timestamp (UTC)            | 2026-09-03 18:00 (`hard_fork_genesis_slot_delta` = 60 slots = 3 hours)                                                                                  |
+| State Finalization window               | Exactly 100 slots = exactly 5 hours between `slot_tx_end` and `slot_chain_end`                                                                          |
 
-Subscribe to the [MinaProtocol/mina releases](https://github.com/MinaProtocol/mina/releases?q=mesa) and watch the [Mina Foundation announcements channel](https://discord.gg/minaprotocol) for the schedule publication.
+Both mainnet packages come from the `stable` channel on `packages.o1test.net`. Run **one** of the two releases:
+
+- **Automode** — install `mina-mainnet-automode=4.0.0-mainnet-893c877` before the stop-transaction-slot. The dispatcher swaps to the Mesa binary by itself. No second upgrade.
+- **Manual** — install `mina-mainnet=3.5.0-mainnet-stop-slot-5e100ee` before the stop-transaction-slot, keep it running until the stop-network-slot, then install the Mesa release when it is published. See [Upgrade Modes](/network-upgrades/mesa/upgrade-modes).
+
+The archive package for both paths is `mina-archive=3.5.0-mainnet-stop-slot-5e100ee`.
 
 ## Devnet
 
-:::warning Values not yet published
-Devnet typically forks ahead of mainnet to give integrators a final dress rehearsal. Schedule will be posted here once announced.
+:::note Devnet forked on 2026-08-19
+Devnet is on Mesa. The values below are historical; they will not change.
 :::
 
-| Field                                   | Value |
-| --------------------------------------- | ----- |
-| Pre-fork (stop-slot) release            | _TBD_ |
-| Mesa release                            | _TBD_ |
-| `stop-transaction-slot` (`slot_tx_end`) | _TBD_ |
-| `stop-network-slot` (`slot_chain_end`)  | _TBD_ |
-| Mesa genesis timestamp (UTC)            | _TBD_ |
+| Field                                   | Value                                                                                                                                               |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pre-fork (stop-slot) release            | [`3.5.0-devnet-stop-slot`](https://github.com/MinaProtocol/mina/releases/tag/3.5.0-devnet-stop-slot) — `mina-devnet=3.5.0-devnet-stop-slot-849edfa` |
+| Automode release                        | [`4.0.0-devnet`](https://github.com/MinaProtocol/mina/releases/tag/4.0.0-devnet) — `mina-devnet-automode=4.0.0-devnet-2dc9218`                      |
+| Mesa release (manual mode only)         | [`4.0.0-devnet-mesa`](https://github.com/MinaProtocol/mina/releases/tag/4.0.0-devnet-mesa) — `mina-devnet=4.0.0-6965b50`                            |
+| `stop-transaction-slot` (`slot_tx_end`) | Slot **413540** — 2026-08-19 10:00 UTC                                                                                                              |
+| `stop-network-slot` (`slot_chain_end`)  | Slot **413640** — 2026-08-19 15:00 UTC                                                                                                              |
+| Mesa genesis timestamp (UTC)            | 2026-08-19 18:00                                                                                                                                    |
+| State Finalization window               | Exactly 100 slots = exactly 5 hours between `slot_tx_end` and `slot_chain_end`                                                                      |
+
+Devnet packages come from the `alpha` channel on `packages.o1test.net`. A node that joins devnet now must use `mina-devnet=4.0.0-6965b50`; the two pre-fork releases can no longer connect.
 
 ## Preflight (archived)
 


### PR DESCRIPTION
## What

The Mesa **Fork Schedule** page showed `TBD` in every row of the Mainnet and Devnet tables. Those values are published now, so this fills them in.

Sources: `genesis_ledgers/mainnet.json` and `genesis_ledgers/devnet.json` in `MinaProtocol/mina`, plus the published GitHub releases. The devnet Mesa genesis timestamp is confirmed against the live devnet daemon (`2026-08-19T10:00-08:00` = 18:00 UTC).

## Mainnet — upgrade day 2026-09-03

| Field | Value |
| --- | --- |
| `slot_tx_end` | 393800 — 2026-09-03 10:00 UTC |
| `slot_chain_end` | 393900 — 2026-09-03 15:00 UTC |
| Mesa genesis | 2026-09-03 18:00 UTC (`hard_fork_genesis_slot_delta` = 60) |
| Stop-slot release | `3.5.0-mainnet-stop-slot` → `mina-mainnet=3.5.0-mainnet-stop-slot-5e100ee` |
| Automode release | `4.0.0-mainnet` → `mina-mainnet-automode=4.0.0-mainnet-893c877` |

## Devnet — forked 2026-08-19

| Field | Value |
| --- | --- |
| `slot_tx_end` | 413540 — 2026-08-19 10:00 UTC |
| `slot_chain_end` | 413640 — 2026-08-19 15:00 UTC |
| Mesa genesis | 2026-08-19 18:00 UTC |
| Mesa release | `4.0.0-devnet-mesa` → `mina-devnet=4.0.0-6965b50` |

## One row stays unspecified

The **mainnet manual-mode Mesa release**. The `4.0.0-mainnet-mesa` tag exists (empty commit, 2026-08-28) but no GitHub release is published — it ships after the stop-network-slot. The row says so rather than guessing a version.

## Also

Each table gets a short note on the apt channel (`stable` for mainnet, `alpha` for devnet) and on which of the two upgrade paths — automode or manual — an operator should follow. The "subscribe for the schedule" line under the mainnet table is dropped, since the schedule is now on the page.

## Testing

`npm run build` passes. `static/llms-full.txt` is regenerated; its diff is scoped to this page. The four broken-anchor warnings are pre-existing on `/network-upgrades/mesa` and are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9KMLrrqme1DZm18PUbMGF