### PR TITLE
docs: fix two broken o1Labs documentation links

### DIFF
--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -307,7 +307,7 @@ A [full node](#full-node) in the Mina protocol that does not participate in cons
 
 ### non-upgradeable
 
-If the verification key cannot be changed, a zkApp smart contract is considered non-upgradeable. You can make a smart contract upgradeable or not upgradeable using [permissions](https://docs.o1labs.org/o1js/zkapps/permissions#upgradeability-of-smart-contracts).
+If the verification key cannot be changed, a zkApp smart contract is considered non-upgradeable. You can make a smart contract upgradeable or not upgradeable using [permissions](https://docs.o1labs.org/o1js/advanced-concepts/ZkApps/upgradability).
 
 ### nonce
 

--- a/docs/zkapps/o1js/indexed-merkle-map.mdx
+++ b/docs/zkapps/o1js/indexed-merkle-map.mdx
@@ -70,7 +70,7 @@ In this example, `IndexedMerkleMap31` is a Merkle map capable of holding up to 2
 
 ### Indexed Merkle Map - API reference
 
-For an example, see the `IndexedMerkleMap` [API reference](https://docs.o1labs.org/o1js/api-reference/namespaces/Experimental/functions/IndexedMerkleMap) in o1js.
+For an example, see the `IndexedMerkleMap` [API reference](https://docs.o1labs.org/o1js/api-reference/variables/IndexedMerkleMap) in o1js.
 
 ## Additional Resources
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -298,7 +298,7 @@ A [full node](#full-node) in the Mina protocol that does not participate in cons
 
 ### non-upgradeable
 
-If the verification key cannot be changed, a zkApp smart contract is considered non-upgradeable. You can make a smart contract upgradeable or not upgradeable using [permissions](https://docs.o1labs.org/o1js/zkapps/permissions#upgradeability-of-smart-contracts).
+If the verification key cannot be changed, a zkApp smart contract is considered non-upgradeable. You can make a smart contract upgradeable or not upgradeable using [permissions](https://docs.o1labs.org/o1js/advanced-concepts/ZkApps/upgradability).
 
 ### nonce
 
@@ -18008,7 +18008,7 @@ In this example, `IndexedMerkleMap31` is a Merkle map capable of holding up to 2
 
 ### Indexed Merkle Map - API reference
 
-For an example, see the `IndexedMerkleMap` [API reference](https://docs.o1labs.org/o1js/api-reference/namespaces/Experimental/functions/IndexedMerkleMap) in o1js.
+For an example, see the `IndexedMerkleMap` [API reference](https://docs.o1labs.org/o1js/api-reference/variables/IndexedMerkleMap) in o1js.
 
 ## Additional Resources
 


### PR DESCRIPTION
Fixes the two links found dead while auditing our outbound references to `docs.o1labs.org` (#1235).

| File | Was | Now | Why |
|---|---|---|---|
| `docs/zkapps/o1js/indexed-merkle-map.mdx:73` | `api-reference/namespaces/Experimental/functions/IndexedMerkleMap` — **404** | `api-reference/variables/IndexedMerkleMap` | `IndexedMerkleMap` is no longer exported from the `Experimental` namespace in o1js 2.15.0 |
| `docs/glossary.mdx:310` | `zkapps/permissions#upgradeability-of-smart-contracts` — 200, **anchor gone** | `advanced-concepts/ZkApps/upgradability` | The upgradeability material moved off the permissions page |

The glossary one is the more annoying of the two: the page returns 200, so nothing flags it, but the reader lands at the top of the permissions page with no upgradeability section anywhere on it. Its live headings are `types-of-permissions`, `types-of-authorizations`, `authorization`, `basic-permission-setup`, `api-reference`.

Both replacement URLs verified live (HTTP 200) on 2026-09-06. `static/llms-full.txt` regenerated so `check-llms-txt` passes.

### Context
This came out of a page-by-page comparison of `MinaProtocol/docs2` against `o1-labs/o1js-documentation-site`, indexed in #1237. It sits alongside #1208, which is delegating the zkApp section to o1Labs — that migration is exactly what makes these outbound links load-bearing, and neither of these two was caught because nothing in CI checks them.

The rest of #1235 — a scheduled CI job covering all 37 in-page links plus the 20 `vercel.json` redirect destinations, and the `documentation.o1labs.org` canonical-host question — is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012A5LmAdLpUcPELjgHg3C5e