### PR TITLE
docs: correct the o1js version wording on the offchain storage page

### DIFF
--- a/docs/zkapps/writing-a-zkapp/feature-overview/offchain-storage.mdx
+++ b/docs/zkapps/writing-a-zkapp/feature-overview/offchain-storage.mdx
@@ -46,13 +46,23 @@ Prior to users accessing published state, it must first undergo settlement. Than
 
 ### Prerequisites
 
-The `OffchainState` API is accessible within the `Experimental` namespace. To use `OffchainState`, import `Experimental` from o1js version 1.9.1 or higher.
+The [`OffchainState`](https://docs.o1labs.org/o1js/api-reference/namespaces/Experimental/variables/OffchainState) API and [`OffchainStateCommitments`](https://docs.o1labs.org/o1js/api-reference/namespaces/Experimental/classes/OffchainStateCommitments) are accessible within the `Experimental` namespace. To use them, import `Experimental` from o1js. The examples on this page are verified against o1js 2.15.0.
 
 ```ts
 import { Experimental } from 'o1js';
 
 const { OffchainState, OffchainStateCommitments } = Experimental;
 ```
+
+:::caution
+
+`OffchainState` lives in the `Experimental` namespace, so its import path is not
+covered by the o1js stability guarantee. o1js 2.15.0 also ships an
+[`Experimental.V2`](https://docs.o1labs.org/o1js/api-reference/namespaces/Experimental/namespaces/V2/)
+namespace. Check the import path against the
+[o1js changelog](https://docs.o1labs.org/o1js/changelog) when you upgrade.
+
+:::
 
 ### Setting up Offchain Storage
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -23340,13 +23340,23 @@ Prior to users accessing published state, it must first undergo settlement. Than
 
 ### Prerequisites
 
-The `OffchainState` API is accessible within the `Experimental` namespace. To use `OffchainState`, import `Experimental` from o1js version 1.9.1 or higher.
+The [`OffchainState`](https://docs.o1labs.org/o1js/api-reference/namespaces/Experimental/variables/OffchainState) API and [`OffchainStateCommitments`](https://docs.o1labs.org/o1js/api-reference/namespaces/Experimental/classes/OffchainStateCommitments) are accessible within the `Experimental` namespace. To use them, import `Experimental` from o1js. The examples on this page are verified against o1js 2.15.0.
 
 ```ts
 
 
 const { OffchainState, OffchainStateCommitments } = Experimental;
 ```
+
+:::caution
+
+`OffchainState` lives in the `Experimental` namespace, so its import path is not
+covered by the o1js stability guarantee. o1js 2.15.0 also ships an
+[`Experimental.V2`](https://docs.o1labs.org/o1js/api-reference/namespaces/Experimental/namespaces/V2/)
+namespace. Check the import path against the
+[o1js changelog](https://docs.o1labs.org/o1js/changelog) when you upgrade.
+
+:::
 
 ### Setting up Offchain Storage
 


### PR DESCRIPTION
Closes #1230.

The prerequisites section said:

> To use `OffchainState`, import `Experimental` from o1js version **1.9.1 or higher**.

Current stable o1js is **2.15.0**. That line is two major versions out of date, and a floor of "1.9.1 or higher" tells a reader nothing about which version the page was actually written against.

### What I checked
The API itself is fine. `Experimental.OffchainState` and `OffchainStateCommitments` are still exported in 2.15.0, and the usage pattern on this page still matches. Only the version line was wrong — so this PR does not touch the code samples.

### What changed
- States 2.15.0 as the verified version rather than a stale floor.
- Links both symbols to their o1Labs API reference entries ([`OffchainState`](https://docs.o1labs.org/o1js/api-reference/namespaces/Experimental/variables/OffchainState), [`OffchainStateCommitments`](https://docs.o1labs.org/o1js/api-reference/namespaces/Experimental/classes/OffchainStateCommitments)) — the page previously had no link to either.
- Adds a `:::caution` noting that the `Experimental` import path carries no stability guarantee, and that 2.15.0 ships an [`Experimental.V2`](https://docs.o1labs.org/o1js/api-reference/namespaces/Experimental/namespaces/V2/) namespace. That namespace is the reason the version line matters: when `OffchainState` moves, this page breaks silently, and the caution is what tells a reader where to look.

All four linked URLs verified live (HTTP 200) on 2026-09-06. `static/llms-full.txt` regenerated so `check-llms-txt` passes.

### Context
From the docs2 ↔ o1Labs overlap comparison indexed in #1237. o1Labs has **no** concept page for offchain storage — `zkapps/provable-inputs` is a 115-word stub — so this page stays canonical on Mina docs and is out of scope for the #1208 delegation. That is precisely why it needs to be kept current here rather than pointed elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012A5LmAdLpUcPELjgHg3C5e