### PR TITLE
docs: point to the o1Labs-only o1js topics

### DIFF
--- a/docs/zkapps/o1js/index.mdx
+++ b/docs/zkapps/o1js/index.mdx
@@ -62,6 +62,26 @@ All of the o1js framework is packaged as a single TypeScript library that can be
 
 Start your o1js journey by learning about [basic zk programming concepts](/zkapps/o1js/basic-concepts).
 
+## Advanced o1js topics
+
+These topics are maintained by o1Labs alongside the library itself and have no
+counterpart in these docs. Follow the links for the current material.
+
+- [Native prover](https://docs.o1labs.org/o1js/advanced-concepts/native-prover) —
+  the native proving backend introduced in o1js 2.15.0, and when to use it.
+- [Serialization](https://docs.o1labs.org/o1js/advanced-concepts/serialization) —
+  serializing provable types and proofs.
+- [Side-loaded verification keys](https://docs.o1labs.org/o1js/advanced-concepts/sideloaded-vks) —
+  verifying proofs whose verification key is supplied at run time.
+- [Analyzing constraint systems](https://docs.o1labs.org/o1js/writing-constraint-systems/analyzing-constraint-systems) —
+  measuring and profiling the size of a circuit.
+- [ZkProgram](https://docs.o1labs.org/o1js/writing-constraint-systems/zk-program) and
+  [ZkProgram proofs](https://docs.o1labs.org/o1js/zkapps/zkprogram-proofs) —
+  writing provable programs outside a `SmartContract`.
+
+For the full o1js API, see the
+[o1js API reference](https://docs.o1labs.org/o1js/api-reference/Introduction).
+
 ## Audits of o1js
 
 * [**Veridise external audit (Q3 2024)**](https://github.com/o1-labs/o1js/blob/a09c5167c4df64f879684e5af14c59cf7a6fce11/audits/VAR_o1js_240318_o1js_V3.pdf).  We engaged Veridise, a security auditing company, to do a full audit of o1js version 1.  Veridise spent 39 person-weeks reviewing o1js in depth, and all issues of medium severity and higher were fixed.

--- a/docs/zkapps/tutorials/index.mdx
+++ b/docs/zkapps/tutorials/index.mdx
@@ -80,6 +80,11 @@ Line numbers are provided for convenience. To prevent copying line numbers and c
 
 The API Reference docs are a detailed resource that is useful after you have familiarized yourself with the basics. See the [o1js Reference](https://docs.o1labs.org/o1js/api-reference/Introduction) docs for an in-depth explanation of all the methods, properties, and interfaces available in o1js.
 
+o1Labs maintains its own tutorial track alongside this one. It currently covers building an
+HMAC circuit in three parts — [basics](https://docs.o1labs.org/o1js/tutorials/hmac/hmac-basics),
+[implementation](https://docs.o1labs.org/o1js/tutorials/hmac/implementation) and
+[tests](https://docs.o1labs.org/o1js/tutorials/hmac/tests).
+
 See the o1Labs blog at https://www.o1labs.org/blog/. For updates about o1js, see https://www.o1labs.org/blog?topics=o1js.
 
 If you're just getting started, watch these step-by-step [zkApp Explainer Videos](https://www.youtube.com/playlist?list=PLItixFkgfjYFw6GPqu6vk4NmclOJpT9lE) that go over how to get started building zkApps. Each tutorial includes a link to the corresponding video. While you're on the Mina Foundation YouTube channel, select **Subscribe** so that new videos will show in your Subscriptions feed.

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -17945,6 +17945,26 @@ All of the o1js framework is packaged as a single TypeScript library that can be
 
 Start your o1js journey by learning about [basic zk programming concepts](/zkapps/o1js/basic-concepts).
 
+## Advanced o1js topics
+
+These topics are maintained by o1Labs alongside the library itself and have no
+counterpart in these docs. Follow the links for the current material.
+
+- [Native prover](https://docs.o1labs.org/o1js/advanced-concepts/native-prover) —
+  the native proving backend introduced in o1js 2.15.0, and when to use it.
+- [Serialization](https://docs.o1labs.org/o1js/advanced-concepts/serialization) —
+  serializing provable types and proofs.
+- [Side-loaded verification keys](https://docs.o1labs.org/o1js/advanced-concepts/sideloaded-vks) —
+  verifying proofs whose verification key is supplied at run time.
+- [Analyzing constraint systems](https://docs.o1labs.org/o1js/writing-constraint-systems/analyzing-constraint-systems) —
+  measuring and profiling the size of a circuit.
+- [ZkProgram](https://docs.o1labs.org/o1js/writing-constraint-systems/zk-program) and
+  [ZkProgram proofs](https://docs.o1labs.org/o1js/zkapps/zkprogram-proofs) —
+  writing provable programs outside a `SmartContract`.
+
+For the full o1js API, see the
+[o1js API reference](https://docs.o1labs.org/o1js/api-reference/Introduction).
+
 ## Audits of o1js
 
 * [**Veridise external audit (Q3 2024)**](https://github.com/o1-labs/o1js/blob/a09c5167c4df64f879684e5af14c59cf7a6fce11/audits/VAR_o1js_240318_o1js_V3.pdf).  We engaged Veridise, a security auditing company, to do a full audit of o1js version 1.  Veridise spent 39 person-weeks reviewing o1js in depth, and all issues of medium severity and higher were fixed.
@@ -22742,6 +22762,11 @@ Line numbers are provided for convenience. To prevent copying line numbers and c
 ## Useful Resources
 
 The API Reference docs are a detailed resource that is useful after you have familiarized yourself with the basics. See the [o1js Reference](https://docs.o1labs.org/o1js/api-reference/Introduction) docs for an in-depth explanation of all the methods, properties, and interfaces available in o1js.
+
+o1Labs maintains its own tutorial track alongside this one. It currently covers building an
+HMAC circuit in three parts — [basics](https://docs.o1labs.org/o1js/tutorials/hmac/hmac-basics),
+[implementation](https://docs.o1labs.org/o1js/tutorials/hmac/implementation) and
+[tests](https://docs.o1labs.org/o1js/tutorials/hmac/tests).
 
 See the o1Labs blog at https://www.o1labs.org/blog/. For updates about o1js, see https://www.o1labs.org/blog?topics=o1js.
 


### PR DESCRIPTION
Part of #1233.

Six topics are documented **only** on `docs.o1labs.org`. I grepped the whole of `docs/` for each — **zero mentions of any of them**. A reader working from Mina docs had no way to learn they exist.

| Topic | Mentions in `docs/` before this PR |
|---|---|
| **Native prover** | 0 |
| Serialization | 0 |
| Side-loaded verification keys | 0 |
| Analyzing constraint systems | 0 |
| ZkProgram / ZkProgram proofs | 0 |
| HMAC tutorial | 0 |

The native prover is the one that stings: it is the flagship performance feature of o1js 2.15.0 and was invisible from here.

### What changed
- **`docs/zkapps/o1js/index.mdx`** — new "Advanced o1js topics" section linking all five, plus the o1js API reference home. Worth noting: the landing page of our o1js section previously carried **no link to the o1js documentation site at all**.
- **`docs/zkapps/tutorials/index.mdx`** — a line noting the o1Labs HMAC tutorial track (3 parts).

Pointers only. Nothing is copied, so this adds no new surface that can drift out of date — which is the whole point of #1208's direction.

All ten URLs verified live (HTTP 200) on 2026-09-06. `static/llms-full.txt` regenerated.

### Two things deliberately left out of this PR

1. **`zkapps/upgrade-mesa`.** o1Labs has its own Mesa upgrade guide, running in parallel with our `network-upgrades/mesa` **during an active upgrade**. That is new duplication forming right now, and it needs an owner decision rather than a link — tracked in #1233.
2. **Per-page cross-links** on `basic-concepts.mdx`, `circuit-writing-primer.mdx`, `bitwise-operations.mdx` and the other 22 pages carrying no o1Labs link (#1229, #1228, #1234). Separate PR, to keep this one reviewable.

### Context
From the docs2 ↔ o1Labs overlap comparison indexed in #1237. This is the "add a pointer" half of #1208 — the gaps that delegation leaves behind when a topic lives only on the other side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012A5LmAdLpUcPELjgHg3C5e