### PR TITLE
docs: cross-link three o1js pages to their o1Labs counterparts

### DIFF
--- a/docs/zkapps/o1js/basic-concepts.mdx
+++ b/docs/zkapps/o1js/basic-concepts.mdx
@@ -28,6 +28,17 @@ import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
 
 o1js is a TypeScript (TS) library for writing general-purpose zero knowledge (zk) programs and writing zk smart contracts for Mina.
 
+For a reference-level treatment of each primitive, see the o1Labs
+[basic types](https://docs.o1labs.org/o1js/basic-types/field) section:
+[Field](https://docs.o1labs.org/o1js/basic-types/field),
+[integers](https://docs.o1labs.org/o1js/basic-types/int),
+[arrays](https://docs.o1labs.org/o1js/basic-types/arrays),
+[structs](https://docs.o1labs.org/o1js/basic-types/structs),
+[keypairs and signatures](https://docs.o1labs.org/o1js/basic-types/keypairs-and-signatures) and
+[hashing](https://docs.o1labs.org/o1js/basic-types/hashing).
+For the constraint-system background to the rules below, see
+[what is a zk constraint system](https://docs.o1labs.org/o1js/getting-started/what-is-a-zk-constraint-system).
+
 ## Field
 
 Field elements are the basic unit of data in zero knowledge proof programming. Each field element can store a number up to almost 256 bits in size. You can think of a field element as a `uint256` in Solidity.
@@ -78,6 +89,8 @@ let b = Bool(true);
 ```
 
 ## Conditionals
+
+See also [conditional logic](https://docs.o1labs.org/o1js/writing-constraint-systems/conditional-logic) on the o1Labs docs.
 
 Traditional conditional statements are not supported by o1js:
 

--- a/docs/zkapps/o1js/bitwise-operations.mdx
+++ b/docs/zkapps/o1js/bitwise-operations.mdx
@@ -16,7 +16,7 @@ import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
 
 Bitwise operations manipulate individual bits within a binary representation of a number. They can, at times, resemble boolean operations but apply to a sequence of bits instead of booleans. Bitwise operations are generally available in most programming languages, including TypeScript. o1js provides versions of them that operate on `Field` elements and result in the necessary circuit constraints to generate a zero knowledge proof of the computation. This is especially useful when implementing hashing algorithms such as SHA256.
 
-In o1js, bitwise operations and their attendant helper functions are implemented as [gadgets](/zkapps/o1js/gadgets).
+In o1js, bitwise operations and their attendant helper functions are implemented as [gadgets](/zkapps/o1js/gadgets). For the signature of each function, see the [`Gadgets` API reference](https://docs.o1labs.org/o1js/api-reference/variables/Gadgets) on the o1Labs docs.
 
 Bitwise operations:
 - [and()](#and)

--- a/docs/zkapps/o1js/circuit-writing-primer.mdx
+++ b/docs/zkapps/o1js/circuit-writing-primer.mdx
@@ -18,6 +18,13 @@ import MigrateBanner from '@site/src/components/snippets/migrate-banner.mdx';
 
 o1js is a library for writing zk circuits in TypeScript.  While many high-level features are abstracted away from the circuit level, this article will focus specifically on the tools that are specific to the unique nature of writing circuits.
 
+o1Labs maintains a dedicated set of constraint-system pages that go deeper on
+each topic covered here:
+[what is a zk constraint system](https://docs.o1labs.org/o1js/getting-started/what-is-a-zk-constraint-system),
+[conditional logic](https://docs.o1labs.org/o1js/writing-constraint-systems/conditional-logic),
+[witnesses](https://docs.o1labs.org/o1js/writing-constraint-systems/witnesses) and
+[analyzing constraint systems](https://docs.o1labs.org/o1js/writing-constraint-systems/analyzing-constraint-systems).
+
 ## What even is a zk circuit?
 
 For our purposes, you can think of a zk circuit as a set of gates, which we can give an input and produce a deterministic output.  We can prove the correct output of the circuit without revealing the inputs.
@@ -281,3 +288,5 @@ These sources heavily influenced the preceding article and go into more depth ab
 
 - Check out [Mastermind at 5 Levels](https://github.com/o1-labs-XT/mastermind-zkApp) for a practical example of how to implement thees concepts to build a game.
 - Read Yunus' article ["Let's Prove"](https://docs.google.com/document/d/1JQPypqNc7nIRbY0c_5zHFI5TbvbCTe1neiSTPxfLmWA/edit?tab=t.0), a complete guide to o1js.
+- The o1Labs [writing constraint systems](https://docs.o1labs.org/o1js/writing-constraint-systems/conditional-logic)
+  section, maintained alongside the library.

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -16567,6 +16567,17 @@ url: /zkapps/o1js/basic-concepts
 
 o1js is a TypeScript (TS) library for writing general-purpose zero knowledge (zk) programs and writing zk smart contracts for Mina.
 
+For a reference-level treatment of each primitive, see the o1Labs
+[basic types](https://docs.o1labs.org/o1js/basic-types/field) section:
+[Field](https://docs.o1labs.org/o1js/basic-types/field),
+[integers](https://docs.o1labs.org/o1js/basic-types/int),
+[arrays](https://docs.o1labs.org/o1js/basic-types/arrays),
+[structs](https://docs.o1labs.org/o1js/basic-types/structs),
+[keypairs and signatures](https://docs.o1labs.org/o1js/basic-types/keypairs-and-signatures) and
+[hashing](https://docs.o1labs.org/o1js/basic-types/hashing).
+For the constraint-system background to the rules below, see
+[what is a zk constraint system](https://docs.o1labs.org/o1js/getting-started/what-is-a-zk-constraint-system).
+
 ## Field
 
 Field elements are the basic unit of data in zero knowledge proof programming. Each field element can store a number up to almost 256 bits in size. You can think of a field element as a `uint256` in Solidity.
@@ -16617,6 +16628,8 @@ let b = Bool(true);
 ```
 
 ## Conditionals
+
+See also [conditional logic](https://docs.o1labs.org/o1js/writing-constraint-systems/conditional-logic) on the o1Labs docs.
 
 Traditional conditional statements are not supported by o1js:
 
@@ -16680,7 +16693,7 @@ url: /zkapps/o1js/bitwise-operations
 
 Bitwise operations manipulate individual bits within a binary representation of a number. They can, at times, resemble boolean operations but apply to a sequence of bits instead of booleans. Bitwise operations are generally available in most programming languages, including TypeScript. o1js provides versions of them that operate on `Field` elements and result in the necessary circuit constraints to generate a zero knowledge proof of the computation. This is especially useful when implementing hashing algorithms such as SHA256.
 
-In o1js, bitwise operations and their attendant helper functions are implemented as [gadgets](/zkapps/o1js/gadgets).
+In o1js, bitwise operations and their attendant helper functions are implemented as [gadgets](/zkapps/o1js/gadgets). For the signature of each function, see the [`Gadgets` API reference](https://docs.o1labs.org/o1js/api-reference/variables/Gadgets) on the o1Labs docs.
 
 Bitwise operations:
 - [and()](#and)
@@ -17013,6 +17026,13 @@ url: /zkapps/o1js/circuit-writing-primer
 
 o1js is a library for writing zk circuits in TypeScript.  While many high-level features are abstracted away from the circuit level, this article will focus specifically on the tools that are specific to the unique nature of writing circuits.
 
+o1Labs maintains a dedicated set of constraint-system pages that go deeper on
+each topic covered here:
+[what is a zk constraint system](https://docs.o1labs.org/o1js/getting-started/what-is-a-zk-constraint-system),
+[conditional logic](https://docs.o1labs.org/o1js/writing-constraint-systems/conditional-logic),
+[witnesses](https://docs.o1labs.org/o1js/writing-constraint-systems/witnesses) and
+[analyzing constraint systems](https://docs.o1labs.org/o1js/writing-constraint-systems/analyzing-constraint-systems).
+
 ## What even is a zk circuit?
 
 For our purposes, you can think of a zk circuit as a set of gates, which we can give an input and produce a deterministic output.  We can prove the correct output of the circuit without revealing the inputs.
@@ -17276,6 +17296,8 @@ These sources heavily influenced the preceding article and go into more depth ab
 
 - Check out [Mastermind at 5 Levels](https://github.com/o1-labs-XT/mastermind-zkApp) for a practical example of how to implement thees concepts to build a game.
 - Read Yunus' article ["Let's Prove"](https://docs.google.com/document/d/1JQPypqNc7nIRbY0c_5zHFI5TbvbCTe1neiSTPxfLmWA/edit?tab=t.0), a complete guide to o1js.
+- The o1Labs [writing constraint systems](https://docs.o1labs.org/o1js/writing-constraint-systems/conditional-logic)
+  section, maintained alongside the library.
 
 ---
 url: /zkapps/o1js/custom-tokens


### PR DESCRIPTION
Part of #1228, #1229, #1234.

Of the 43 pages left under `docs/zkapps/`, **25 carry no link to `docs.o1labs.org` at all**. This PR takes the three where an o1Labs counterpart clearly exists and is the more current reference.

| Page | Added | Why |
|---|---|---|
| `o1js/circuit-writing-primer.mdx` | `conditional-logic`, `witnesses`, `analyzing-constraint-systems`, `what-is-a-zk-constraint-system` | o1Labs splits this material across three maintained pages; our single 1531-word primer linked to none of them (#1228) |
| `o1js/basic-concepts.mdx` | the six `basic-types/*` pages + `what-is-a-zk-constraint-system` + `conditional-logic` | o1Labs is more granular on the primitives than this page is (#1229) |
| `o1js/bitwise-operations.mdx` | `api-reference/variables/Gadgets` | The page describes these functions as gadgets but never linked their signatures (#1234) |

The intent follows the division of labour in #1208: the zkApp-context framing stays on Mina docs, the reference detail is on o1Labs. Nothing is copied and nothing is deleted — these are links only.

Two of the linked pages (`basic-types/arrays`, `basic-types/structs`, `basic-types/keypairs-and-signatures`) were not in the original comparison at all; they turned up when I diffed the live o1Labs sitemap against `docs/`.

All eleven URLs verified live (HTTP 200) on 2026-09-06. `static/llms-full.txt` regenerated.

### Not in this PR
The other 22 link-less pages. Some legitimately have no counterpart — `install-zkapp-cli.mdx` and `how-to-deploy-a-zkapp.mdx` are Mina-canonical by design — and the rest are covered by the stale-content issues (#1231, #1232) where a link is not the fix. #1234 tracks the sweep.

### Context
From the docs2 ↔ o1Labs overlap comparison indexed in #1237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012A5LmAdLpUcPELjgHg3C5e